### PR TITLE
feat: [WQ-61] 공통응답 BaseResonse에서 불필요한 error 필드 제거

### DIFF
--- a/src/main/kotlin/com/wq/demo/web/common/BaseResponse.kt
+++ b/src/main/kotlin/com/wq/demo/web/common/BaseResponse.kt
@@ -3,6 +3,5 @@ package com.wq.demo.web.common
 data class BaseResponse<T> (
     val success: Boolean,
     val message: String,
-    val data: T?,
-    val error: String? = null
+    val data: T?
 )

--- a/src/main/kotlin/com/wq/demo/web/common/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/wq/demo/web/common/GlobalExceptionHandler.kt
@@ -1,0 +1,39 @@
+package com.wq.demo.web.common
+
+import com.wq.demo.shared.error.ApiException
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+
+@RestControllerAdvice
+class GlobalExceptionHandler {
+
+    companion object {
+        private val log: Logger = LoggerFactory.getLogger(GlobalExceptionHandler::class.java)
+    }
+
+    @ExceptionHandler(ApiException::class)
+    fun handleApiException(e: ApiException): ResponseEntity<BaseResponse<Nothing>> {
+
+        log.error(e.extractExceptionLocation() + e.message)
+        val status = HttpStatus.valueOf(e.code.getStatus())
+        val body = Responses.fail(e.code)
+        return ResponseEntity.status(status).body(body)
+    }
+
+    // 예상 못 한 예외 처리
+    @ExceptionHandler(Exception::class)
+    fun handleUnexpected(e: Exception): ResponseEntity<BaseResponse<Nothing>> {
+        log.error("[예상치 못한 예외 발생] $e")
+        val status = HttpStatus.INTERNAL_SERVER_ERROR
+        val body = BaseResponse(
+            success = false,
+            message = e.message ?: "Internal server error",
+            data = null
+        )
+        return ResponseEntity.status(status).body(body)
+    }
+}

--- a/src/main/kotlin/com/wq/demo/web/common/Responses.kt
+++ b/src/main/kotlin/com/wq/demo/web/common/Responses.kt
@@ -7,8 +7,8 @@ object Responses {
         message: String = "요청에 성공적으로 응답하였습니다.",
         data: T? = null
     ) : BaseResponse<T> =
-        BaseResponse(true, message, data, null)
+        BaseResponse(true, message, data)
 
     fun fail(code: ApiResponseCode) : BaseResponse<Nothing> =
-        BaseResponse(false, code.getMessage(), null, code.toString())
+        BaseResponse(false, code.getMessage(), null)
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
closed [WQ-61]

## 📝 작업 내용

### 수정사항
- BaseResponse에서 error 필드 제거
  - front에서 불필요.

### 추가사항
- Api Global Handler 추가
  - 이전 PR 추가 한 줄 알았는데 못함.
  - throw ApiException으로 공통 에러 핸들링 추가.
