### PR TITLE
feat: [WQ-50] 공통 TimeUtil 생성

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,10 +38,20 @@ dependencies {
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
-	testImplementation("io.kotest:kotest-runner-junit5")
-	testImplementation("io.kotest:kotest-assertions-core")
-	testImplementation("io.kotest:kotest-assertions-json")
-	testImplementation("io.kotest:kotest-property")
+
+
+	// Kotest 버전 변수로 관리
+	val kotestVersion = "5.9.1"
+
+	testImplementation("io.kotest:kotest-runner-junit5:$kotestVersion")
+	testImplementation("io.kotest:kotest-assertions-core:$kotestVersion")
+	testImplementation("io.kotest:kotest-assertions-json:$kotestVersion")
+	testImplementation("io.kotest:kotest-property:$kotestVersion")
+	testImplementation("io.kotest.extensions:kotest-extensions-spring:1.1.3")
+
+	testImplementation("com.fasterxml.jackson.core:jackson-databind:2.17.+")
+	testImplementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.17.+")
+	testImplementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.17.+")
 }
 
 kotlin {
@@ -57,6 +67,9 @@ allOpen {
 }
 
 tasks.withType<Test> {
+	useJUnitPlatform()
+}
+tasks.test {
 	useJUnitPlatform()
 }
 noArg {

--- a/src/main/kotlin/com/wq/demo/shared/config/AuditingConfig.kt
+++ b/src/main/kotlin/com/wq/demo/shared/config/AuditingConfig.kt
@@ -1,0 +1,16 @@
+package com.wq.demo.shared.config
+
+import com.wq.demo.shared.time.TimeProvider
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.auditing.DateTimeProvider
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing
+import java.util.Optional
+
+@Configuration
+@EnableJpaAuditing(dateTimeProviderRef = "dateTimeProvider")
+class AuditingConfig(private val time: TimeProvider) {
+    @Bean
+    fun dateTimeProvider(): DateTimeProvider =
+        DateTimeProvider { Optional.of(time.nowInstant()) } // UTC Instant 기록
+}

--- a/src/main/kotlin/com/wq/demo/shared/entity/BaseEntity.kt
+++ b/src/main/kotlin/com/wq/demo/shared/entity/BaseEntity.kt
@@ -1,0 +1,23 @@
+package com.wq.demo.shared.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.MappedSuperclass
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.time.Instant
+
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener::class)
+abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    lateinit var createdAt: Instant   // UTC
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    lateinit var updatedAt: Instant   // UTC
+}

--- a/src/main/kotlin/com/wq/demo/shared/time/JacksonTimeConfig.kt
+++ b/src/main/kotlin/com/wq/demo/shared/time/JacksonTimeConfig.kt
@@ -1,0 +1,53 @@
+package com.wq.demo.shared.time
+
+import com.fasterxml.jackson.core.JsonGenerator
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.JsonDeserializer
+import com.fasterxml.jackson.databind.JsonSerializer
+import com.fasterxml.jackson.databind.SerializerProvider
+import com.fasterxml.jackson.databind.module.SimpleModule
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import java.time.Instant
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+
+private val ISO_WITH_SECONDS: DateTimeFormatter =
+    DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssXXX")
+
+/** Instant -> ISO-8601(+offset)로 ZoneProvider 기준 변환 */
+class InstantToZoneSerializer(
+    private val zoneProvider: ZoneProvider
+) : JsonSerializer<Instant>() { // Instant -> JSON 문자열로 변환하는 클래스
+    override fun serialize(value: Instant?, gen: JsonGenerator, serializers: SerializerProvider) {
+        if (value == null) { gen.writeNull(); return }
+        val offset = value
+            .atZone(ZoneOffset.UTC)
+            .withZoneSameInstant(zoneProvider.zoneId())
+            .toOffsetDateTime()
+        gen.writeString(ISO_WITH_SECONDS.format(offset)) // ← 항상 HH:mm:ss 출력
+    }
+}
+
+/** ISO 문자열 -> Instant (요청 바디 수신 시) */
+class InstantFromIsoDeserializer : JsonDeserializer<Instant>() {
+    override fun deserialize(p: com.fasterxml.jackson.core.JsonParser, ctxt: DeserializationContext): Instant {
+        val s = p.text
+        return runCatching { OffsetDateTime.parse(s).toInstant() }
+            .getOrElse { Instant.parse(s) }
+    }
+}
+
+/**
+ * Jackson에 커스텀 Serializer/Deserializer를 등록하는 설정 클래스
+ */
+@Configuration
+class JacksonTimeConfig(private val zoneProvider: ZoneProvider) {
+    @Bean
+    fun instantZoneModule(): SimpleModule =
+        SimpleModule().apply {
+            addSerializer(Instant::class.java, InstantToZoneSerializer(zoneProvider))
+            addDeserializer(Instant::class.java, InstantFromIsoDeserializer())
+        }
+}

--- a/src/main/kotlin/com/wq/demo/shared/time/TimeProvider.kt
+++ b/src/main/kotlin/com/wq/demo/shared/time/TimeProvider.kt
@@ -1,0 +1,21 @@
+package com.wq.demo.shared.time
+
+import org.springframework.stereotype.Component
+import java.time.Clock
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.ZoneOffset
+import java.time.ZonedDateTime
+
+/** 저장/계산용 'UTC 시계' */
+@Component
+class TimeProvider(
+    private val clock: Clock = Clock.systemUTC()
+) {
+    fun nowInstant(): Instant = Instant.now(clock)                       // 가장 안전한 저장 타입
+
+    fun nowUtc(): LocalDateTime = LocalDateTime.ofInstant(nowInstant(), ZoneOffset.UTC)
+
+    fun at(zone: ZoneId): ZonedDateTime = nowInstant().atZone(zone)
+}

--- a/src/main/kotlin/com/wq/demo/shared/time/ZoneProvider.kt
+++ b/src/main/kotlin/com/wq/demo/shared/time/ZoneProvider.kt
@@ -1,0 +1,17 @@
+package com.wq.demo.shared.time
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+import java.time.ZoneId
+
+/** 응답에 사용할 기본 타임존 제공자 */
+interface ZoneProvider { fun zoneId(): ZoneId }
+
+/** APP_TIME_DEFAULT_ZONE 없으면 기본 Asia/Seoul */
+@Component
+class PropertiesZoneProvider(
+    @Value("\${app.time.default-zone}")
+    private val defaultZone: String
+) : ZoneProvider {
+    override fun zoneId(): ZoneId = ZoneId.of(defaultZone)
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,11 +16,21 @@ spring:
       hibernate:
         format_sql: true
         use_sql_comments: true
+        jdbc:
+          time_zone: UTC
+
+  jackson:
+    time-zone: UTC
 
   h2:
     console:
       enabled: true
       path: /h2-console
+
+app:
+  time:
+    default-zone: ${APP_DEFAULT_ZONE:Asia/Seoul} # 환경변수 APP_DEFAULT_ZONE이 있으면 그걸 쓰고, 없으면 Asia/Seoul
+
 
 logging:
   level:

--- a/src/test/kotlin/com/wq/demo/integration/JacksonInstantIntegrationTest.kt
+++ b/src/test/kotlin/com/wq/demo/integration/JacksonInstantIntegrationTest.kt
@@ -1,0 +1,67 @@
+package com.wq.demo.integration
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.wq.demo.integration._tnote._TNote
+import com.wq.demo.integration._tnote._TNoteRepository
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.extensions.spring.SpringExtension
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Import
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.get
+import java.time.Instant
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+
+@AutoConfigureMockMvc
+@SpringBootTest
+class JacksonInstantIntegrationTest(
+    private val repo: _TNoteRepository,
+    private val mockMvc: MockMvc,
+    private val objectMapper: ObjectMapper
+) : StringSpec({
+
+    "UTC Instant가 저장/조회 시 동일하다" {
+        // given
+        val utc = Instant.parse("2025-08-12T00:00:00Z")
+        val saved = repo.save(_TNote(title = "hello", publishedAt = utc))
+
+        // when
+        val found = repo.findById(saved.id!!).orElseThrow()
+
+        // then
+        found.publishedAt shouldBe utc
+    }
+
+    "응답 JSON은 +09:00 및 :ss로 나가고 시점은 동일하다" {
+        // given
+        val utc = Instant.parse("2025-08-12T00:00:00Z")
+        val saved = repo.save(_TNote(title = "hello", publishedAt = utc))
+
+        // when
+        val res = mockMvc.get("/test-notes/{id}", saved.id!!) {
+            accept = MediaType.APPLICATION_JSON
+        }.andReturn().response
+        res.status shouldBe 200
+
+        // then: 포맷 문자열 검증 (+09:00 & :ss)
+        val body = res.contentAsString
+        body shouldContain "\"publishedAt\":\"2025-08-12T09:00:00+09:00\""
+
+        // 의미 검증: 파싱하여 오프셋/Instant 동일성 확인
+        val node: JsonNode = objectMapper.readTree(body)
+        val iso = node["publishedAt"]?.asText()
+            ?: error("publishedAt 필드가 없음.")
+        val parsed = OffsetDateTime.parse(iso)
+
+        parsed.offset shouldBe ZoneOffset.ofHours(9)  // 응답은 +09:00
+        parsed.toInstant() shouldBe utc               // 시점은 동일(UTC)
+    }
+}) {
+    override fun extensions() = listOf(SpringExtension)
+}

--- a/src/test/kotlin/com/wq/demo/integration/_tnote/_TNote.kt
+++ b/src/test/kotlin/com/wq/demo/integration/_tnote/_TNote.kt
@@ -1,0 +1,21 @@
+package com.wq.demo.integration._tnote
+
+import com.wq.demo.shared.entity.BaseEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.time.Instant
+
+@Entity
+@Table(name = "_t_note")
+class _TNote(
+    @Column(nullable = false) var title: String = "t",
+    @Column(nullable = false) var publishedAt: Instant = Instant.now()
+) : BaseEntity() {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Long? = null
+}

--- a/src/test/kotlin/com/wq/demo/integration/_tnote/_TNoteController.kt
+++ b/src/test/kotlin/com/wq/demo/integration/_tnote/_TNoteController.kt
@@ -1,0 +1,33 @@
+package com.wq.demo.integration._tnote
+
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.time.Instant
+
+@RestController
+@RequestMapping("/test-notes")
+class _TNoteController(
+    private val repo: _TNoteRepository
+) {
+    data class Dto(
+        val id: Long,
+        val title: String,
+        val publishedAt: Instant,
+        val createdAt: Instant,
+        val updatedAt: Instant
+    )
+
+    @GetMapping("/{id}")
+    fun get(@PathVariable id: Long): Dto =
+        repo.findById(id).orElseThrow().let {
+            Dto(
+                id = it.id!!,
+                title = it.title,
+                publishedAt = it.publishedAt,
+                createdAt = it.createdAt,
+                updatedAt = it.updatedAt
+            )
+        }
+}

--- a/src/test/kotlin/com/wq/demo/integration/_tnote/_TNoteRepository.kt
+++ b/src/test/kotlin/com/wq/demo/integration/_tnote/_TNoteRepository.kt
@@ -1,0 +1,5 @@
+package com.wq.demo.integration._tnote
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface _TNoteRepository : JpaRepository<_TNote, Long>

--- a/src/test/kotlin/com/wq/demo/unit/JacksonInstantModuleTest.kt
+++ b/src/test/kotlin/com/wq/demo/unit/JacksonInstantModuleTest.kt
@@ -1,0 +1,67 @@
+package com.wq.demo.unit
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.wq.demo.shared.time.ZoneProvider
+import io.kotest.core.spec.style.StringSpec
+import java.time.Instant
+import java.time.ZoneId
+import com.fasterxml.jackson.databind.module.SimpleModule
+import com.wq.demo.shared.time.InstantFromIsoDeserializer
+import com.wq.demo.shared.time.InstantToZoneSerializer
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+
+class JacksonInstantModuleTest : StringSpec({
+
+    fun mapperWith(zoneId: String): ObjectMapper {
+        val zoneProvider = object : ZoneProvider {
+            override fun zoneId(): ZoneId = ZoneId.of(zoneId)
+        }
+        val module = SimpleModule().apply {
+            addSerializer(Instant::class.java, InstantToZoneSerializer(zoneProvider))
+            addDeserializer(Instant::class.java, InstantFromIsoDeserializer())
+        }
+        return ObjectMapper()
+            .registerModule(JavaTimeModule())
+            .registerModule(module)
+            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+    }
+
+    "Instant → JSON 직렬화 시 Asia/Seoul(+09:00)로 변환된다" {
+        val mapper = mapperWith("Asia/Seoul")
+        val instant = Instant.parse("2025-08-12T00:00:00Z")
+
+        val json = mapper.writeValueAsString(mapOf("at" to instant))
+        json shouldContain "\"at\":\"2025-08-12T09:00:00+09:00\""
+    }
+
+    "Instant → JSON 직렬화 시 Europe/Paris(+02:00 또는 +01:00)로 변환된다" {
+        val mapper = mapperWith("Europe/Paris")
+        val instant = Instant.parse("2025-08-12T00:00:00Z")
+
+        val json = mapper.writeValueAsString(mapOf("at" to instant))
+        json shouldContain "+02:00" // 8월은 CEST(+02:00)
+    }
+
+    "오프셋 포함 ISO 문자열 → Instant(UTC)로 역직렬화된다" {
+        val mapper = mapperWith("Asia/Seoul")
+        val json = """{"at":"2025-08-12T09:00:00+09:00"}"""
+
+        val node = mapper.readTree(json)
+        val inst = mapper.treeToValue(node.get("at"), Instant::class.java)
+
+        inst shouldBe Instant.parse("2025-08-12T00:00:00Z")
+    }
+
+    "UTC(Z) 문자열 → Instant(UTC)로 역직렬화된다" {
+        val mapper = mapperWith("Asia/Seoul")
+        val json = """{"at":"2025-08-12T00:00:00Z"}"""
+
+        val node = mapper.readTree(json)
+        val inst = mapper.treeToValue(node.get("at"), Instant::class.java)
+
+        inst shouldBe Instant.parse("2025-08-12T00:00:00Z")
+    }
+})


### PR DESCRIPTION
## #️⃣ 연관된 이슈
closed [WQ-50][wq-50]

## 📝 작업 내용

- 저장은 UTC Instant, 응답은 환경 타임존으로 자동 변환 (Jackson 전역 모듈)
  - DB에 저장될 때는 UTC 로 저장되고, 외부에 json으로 응답할 때는 자동 직렬화해서 KST 시간으로 보내주도록 설정하였습니다.
- 포맷은 yyyy-MM-dd'T'HH:mm:ssXXX 로 고정 
  - 항상 초(:ss) 포함, 오프셋 명시
- JPA Auditing으로 createdAt/updatedAt 자동 기록(UTC)
- 테스트:
  - 유닛: 모듈 직렬화/역직렬화 규칙 검증
  - 통합: Spring 전역 ObjectMapper 반영 확인

- 응답 DTO 생성 시, 아래와 같이 사용해주시면 됩니다.
```kotlin
data class MemberResponseDto(
    val id: Long,
    val email: String,
    val createdAt: Instant,   // Instant로 선언 -> jackson이 직렬화 할 때, 자동 변환.
    val updatedAt: Instant   // Instant로 선언
)
```

## 📷 스크린샷

> CICD 적용 전에는 테스트 코드 통과 내역을 스크린 샷에 첨부하겠습니다.

<img width="70%" height="478" alt="image" src="https://github.com/user-attachments/assets/dbe3fc00-0cf3-4fc9-9578-e7d68fca9d10" />

## 💬 리뷰 요구사항

- 저장을 UTC, 전달을 default Time으로 따로 둬서 관리한 이유는 : 
  - 한국 외의 서비스를 진행할 수도 있다고 들었고, 그렇기 위해서는 저장은 UTC로 통일해서 꼬이는 상황을 막고
  - FE/Mobile 에 전달할 때 default TimeZone 시간으로 자동 직렬화해서 보내면 개발자 개입 없이 createdAt, updatedAt이 관리될 것이라 생각했습니다.
- default timezone은 환경변수로 따로 주입하지 않으면 Asia/Seoul로 설정, 주입했을 때에는 해당 TimeZone으로 구성하도록 설계하였습니다.


[WQ-50]: https://growgrammers.atlassian.net/browse/WQ-50?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[WQ-62]: https://growgrammers.atlassian.net/browse/WQ-62?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ