### PR TITLE
Feat: [WQ-59] 이메일 로그인 구현

### DIFF
--- a/src/main/kotlin/com/wq/auth/api/controller/member/MemberApiDocs.kt
+++ b/src/main/kotlin/com/wq/auth/api/controller/member/MemberApiDocs.kt
@@ -1,0 +1,43 @@
+package com.wq.auth.api.controller.member
+
+import com.wq.auth.api.controller.member.request.EmailLoginRequestDto
+import com.wq.auth.web.common.response.BaseResponse
+import com.wq.auth.web.common.response.FailResponse
+import com.wq.auth.web.common.response.SuccessResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.web.bind.annotation.RequestBody
+
+@Tag(name = "회원", description = "로그인, 로그아웃 등 회원 관련 API")
+interface MemberApiDocs {
+
+    @Operation(
+        summary = "이메일 로그인",
+        description = "회원 가입을 한 사용자 라면, 회원 이메일로 로그인하고 회원 가입을 하지 않은 사용자라면 회원가입 후 AccessToken과 RefreshToken을 발급합니다."
+    )
+
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "로그인 성공",
+                content = [Content(schema = Schema(implementation = SuccessResponse::class))]
+            ),
+            ApiResponse(
+                responseCode = "401",
+                description = "이메일 인증 실패",
+                content = [Content(schema = Schema(implementation = FailResponse::class))]
+            ),
+            ApiResponse(
+                responseCode = "500",
+                description = "회원 정보를 저장하는데 실패했습니다.",
+                content = [Content(schema = Schema(implementation = FailResponse::class))]
+            )
+        ]
+    )
+    fun emailLogin(@RequestBody req: EmailLoginRequestDto): BaseResponse
+}

--- a/src/main/kotlin/com/wq/auth/api/controller/member/MemberController.kt
+++ b/src/main/kotlin/com/wq/auth/api/controller/member/MemberController.kt
@@ -1,11 +1,32 @@
 package com.wq.auth.api.controller.member
 
+import com.wq.auth.api.controller.member.request.EmailLoginRequestDto
+import com.wq.auth.api.domain.email.AuthEmailService
+import com.wq.auth.api.domain.email.error.EmailException
 import com.wq.auth.api.domain.member.entity.MemberEntity
 import com.wq.auth.api.domain.member.MemberService
+import com.wq.auth.web.common.response.BaseResponse
+import com.wq.auth.web.common.response.Responses
 import org.springframework.web.bind.annotation.*
 
 @RestController
-class MemberController(private val memberService: MemberService) {
+class MemberController(private val memberService: MemberService,
+    private val emailService: AuthEmailService
+) {
+
+    //apiDocs 추가
+    @PostMapping("api/v1/auth/members/email-login")
+    fun emailLogin(@RequestBody req: EmailLoginRequestDto): BaseResponse {
+        return try{
+            emailService.verifyCode(req.email, req.code)
+            val resp = memberService.emailLogin(req.email)
+            Responses.success(message = "로그인에 성공했습니다.", data = resp)
+            //멤버 에러 처리 추가
+        } catch (e: EmailException) {
+            //이메일 인증 실패 에러나 멤버 에러를 같이 쓸 수 있어야 함
+            Responses.fail(e.emailCode)
+        }
+    }
 
     @GetMapping("/members")
     fun getAll(): List<MemberEntity> = memberService.getAll()

--- a/src/main/kotlin/com/wq/auth/api/controller/member/request/EmailLoginRequestDto.kt
+++ b/src/main/kotlin/com/wq/auth/api/controller/member/request/EmailLoginRequestDto.kt
@@ -1,0 +1,3 @@
+package com.wq.auth.api.controller.member.request
+
+data class EmailLoginRequestDto (val email: String, val code: String)

--- a/src/main/kotlin/com/wq/auth/api/controller/member/response/LoginResponseDto.kt
+++ b/src/main/kotlin/com/wq/auth/api/controller/member/response/LoginResponseDto.kt
@@ -1,0 +1,7 @@
+package com.wq.auth.api.controller.member.response
+
+data class LoginResponseDto(
+    val accessToken: String,
+    val refreshToken: String,
+    val expiredAt: Long
+)

--- a/src/main/kotlin/com/wq/auth/api/controller/member/response/LoginResponseDto.kt
+++ b/src/main/kotlin/com/wq/auth/api/controller/member/response/LoginResponseDto.kt
@@ -4,4 +4,9 @@ data class LoginResponseDto(
     val accessToken: String,
     val refreshToken: String,
     val expiredAt: Long
-)
+) {
+    companion object {
+        fun fromTokens(accessToken: String, refreshToken: String, expiredAt: Long) =
+            LoginResponseDto(accessToken, refreshToken, expiredAt)
+    }
+}

--- a/src/main/kotlin/com/wq/auth/api/domain/email/AuthEmailService.kt
+++ b/src/main/kotlin/com/wq/auth/api/domain/email/AuthEmailService.kt
@@ -41,7 +41,7 @@ class AuthEmailService(
         }
     }
 
-    private fun validateEmailFormat(email: String) {
+    fun validateEmailFormat(email: String) {
         try {
             InternetAddress(email).validate()
         } catch (e: Exception) {

--- a/src/main/kotlin/com/wq/auth/api/domain/member/AuthProviderRepository.kt
+++ b/src/main/kotlin/com/wq/auth/api/domain/member/AuthProviderRepository.kt
@@ -1,0 +1,8 @@
+package com.wq.auth.api.domain.member
+
+import com.wq.auth.api.domain.member.entity.AuthProviderEntity
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface AuthProviderRepository : JpaRepository<AuthProviderEntity, Long> {
+    fun findByEmail(email: String): AuthProviderEntity?
+}

--- a/src/main/kotlin/com/wq/auth/api/domain/member/MemberRepository.kt
+++ b/src/main/kotlin/com/wq/auth/api/domain/member/MemberRepository.kt
@@ -5,4 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 
 @Repository
-interface MemberRepository : JpaRepository<MemberEntity, Long>
+interface MemberRepository : JpaRepository<MemberEntity, Long> {
+    fun existsByNickname(nickname: String): Boolean
+}

--- a/src/main/kotlin/com/wq/auth/api/domain/member/MemberService.kt
+++ b/src/main/kotlin/com/wq/auth/api/domain/member/MemberService.kt
@@ -1,10 +1,95 @@
 package com.wq.auth.api.domain.member
 
+import com.wq.auth.api.controller.member.response.LoginResponseDto
+import com.wq.auth.api.domain.member.entity.AuthProviderEntity
 import com.wq.auth.api.domain.member.entity.MemberEntity
+import com.wq.auth.api.domain.member.entity.ProviderType
+import com.wq.auth.jwt.JwtProperties
+import com.wq.auth.jwt.JwtProvider
+import com.wq.auth.shared.utils.NicknameGenerator
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 @Service
-class MemberService(private val memberRepository: MemberRepository) {
+class MemberService(
+    private val memberRepository: MemberRepository,
+    private val authProviderRepository: AuthProviderRepository,
+    private val jwtProvider: JwtProvider,
+    private val nicknameGenerator: NicknameGenerator,
+    private val jwtProperties: JwtProperties
+
+) {
+    @Transactional
+    fun emailLogin(email: String): LoginResponseDto {
+        val email = email
+        val existingUser = authProviderRepository.findByEmail(email)
+
+        return if (existingUser != null) {
+            // 이미 가입된 사용자 → 로그인 처리 및 JWT 발급
+            val accessToken = jwtProvider.createAccessToken(
+                subject = existingUser.member.id.toString(),
+                //굳이 닉네임을 넣어줘야하나
+                extraClaims = mapOf("nickname" to existingUser.member.nickname)
+            )
+            val refreshToken = jwtProvider.createRefreshToken(subject = existingUser.member.id.toString())
+            //리프레시 토큰 db에 넣어두고 비교 할 때 사용해야함
+            //까보고 그냥 멤버로 줘도 되는거 아닌가
+            //그래도 있어야지..
+            val expiredAt = jwtProperties.accessExp.toMillis() + System.currentTimeMillis()
+
+            //만드는 함수를 추가해두고 쓸지
+            LoginResponseDto(
+                accessToken = accessToken,
+                refreshToken = refreshToken,
+                expiredAt = expiredAt
+            )
+        } else {
+            // 없는 이메일 → 회원가입 로직
+            signUp(email)
+        }
+    }
+
+    @Transactional
+    fun signUp(email: String): LoginResponseDto {
+        var nickname: String
+        do {
+            nickname = nicknameGenerator.generate()
+        } while (memberRepository.existsByNickname(nickname))
+
+        //이메일 인증 db에 해당 이메일로 된 컬럼이 없는 경우
+        //에러 반환
+
+        // 이메일 인증 성공시
+        val member = MemberEntity(
+            nickname = nickname,
+            isEmailVerified = true
+        )
+
+        memberRepository.save(member)
+
+        val provider = AuthProviderEntity(
+            member = member,
+            providerType = ProviderType.valueOf(ProviderType.EMAIL.toString()),
+            email = email
+        )
+        authProviderRepository.save(provider)
+
+        val accessToken = jwtProvider.createAccessToken(
+            subject = member.id.toString(),
+            extraClaims = mapOf("nickname" to nickname)
+        )
+        val refreshToken = jwtProvider.createRefreshToken(subject = member.id.toString())
+        val expiredAt = jwtProperties.accessExp.toMillis() + System.currentTimeMillis()
+
+        return LoginResponseDto(
+            accessToken = accessToken,
+            refreshToken = refreshToken,
+            expiredAt = expiredAt
+        )
+        
+        //에러 처리 추가
+    }
+
 
     fun getAll(): List<MemberEntity> = memberRepository.findAll()
 

--- a/src/main/kotlin/com/wq/auth/api/domain/member/MemberService.kt
+++ b/src/main/kotlin/com/wq/auth/api/domain/member/MemberService.kt
@@ -1,9 +1,9 @@
 package com.wq.auth.api.domain.member
 
 import com.wq.auth.api.controller.member.response.LoginResponseDto
+import com.wq.auth.api.domain.email.AuthEmailService
 import com.wq.auth.api.domain.member.entity.AuthProviderEntity
 import com.wq.auth.api.domain.member.entity.MemberEntity
-import com.wq.auth.api.domain.member.entity.ProviderType
 import com.wq.auth.jwt.JwtProperties
 import com.wq.auth.jwt.JwtProvider
 import com.wq.auth.shared.utils.NicknameGenerator
@@ -12,6 +12,7 @@ import org.springframework.transaction.annotation.Transactional
 
 @Service
 class MemberService(
+    private val authEmailService: AuthEmailService,
     private val memberRepository: MemberRepository,
     private val authProviderRepository: AuthProviderRepository,
     private val jwtProvider: JwtProvider,
@@ -21,28 +22,17 @@ class MemberService(
 ) {
     @Transactional
     fun emailLogin(email: String): LoginResponseDto {
-        val email = email
         val existingUser = authProviderRepository.findByEmail(email)
 
         return if (existingUser != null) {
             // 이미 가입된 사용자 → 로그인 처리 및 JWT 발급
-            val accessToken = jwtProvider.createAccessToken(
-                subject = existingUser.member.id.toString(),
-                //굳이 닉네임을 넣어줘야하나
-                extraClaims = mapOf("nickname" to existingUser.member.nickname)
-            )
+            val accessToken = jwtProvider.createAccessToken(subject = existingUser.member.id.toString())
             val refreshToken = jwtProvider.createRefreshToken(subject = existingUser.member.id.toString())
             //리프레시 토큰 db에 넣어두고 비교 할 때 사용해야함
             //까보고 그냥 멤버로 줘도 되는거 아닌가
             //그래도 있어야지..
             val expiredAt = jwtProperties.accessExp.toMillis() + System.currentTimeMillis()
-
-            //만드는 함수를 추가해두고 쓸지
-            LoginResponseDto(
-                accessToken = accessToken,
-                refreshToken = refreshToken,
-                expiredAt = expiredAt
-            )
+            LoginResponseDto.fromTokens(accessToken, refreshToken, expiredAt)
         } else {
             // 없는 이메일 → 회원가입 로직
             signUp(email)
@@ -51,45 +41,27 @@ class MemberService(
 
     @Transactional
     fun signUp(email: String): LoginResponseDto {
+
+        authEmailService.validateEmailFormat(email)
+
         var nickname: String
         do {
             nickname = nicknameGenerator.generate()
+            //중복 닉네임인 경우
         } while (memberRepository.existsByNickname(nickname))
 
-        //이메일 인증 db에 해당 이메일로 된 컬럼이 없는 경우
-        //에러 반환
-
-        // 이메일 인증 성공시
-        val member = MemberEntity(
-            nickname = nickname,
-            isEmailVerified = true
-        )
-
+        val member = MemberEntity.createEmailVerifiedMember(nickname)
         memberRepository.save(member)
 
-        val provider = AuthProviderEntity(
-            member = member,
-            providerType = ProviderType.valueOf(ProviderType.EMAIL.toString()),
-            email = email
-        )
+        val provider = AuthProviderEntity.createEmailProvider(member, email)
         authProviderRepository.save(provider)
 
-        val accessToken = jwtProvider.createAccessToken(
-            subject = member.id.toString(),
-            extraClaims = mapOf("nickname" to nickname)
-        )
+        val accessToken = jwtProvider.createAccessToken(subject = member.id.toString())
         val refreshToken = jwtProvider.createRefreshToken(subject = member.id.toString())
         val expiredAt = jwtProperties.accessExp.toMillis() + System.currentTimeMillis()
 
-        return LoginResponseDto(
-            accessToken = accessToken,
-            refreshToken = refreshToken,
-            expiredAt = expiredAt
-        )
-        
-        //에러 처리 추가
+        return LoginResponseDto.fromTokens(accessToken, refreshToken, expiredAt)
     }
-
 
     fun getAll(): List<MemberEntity> = memberRepository.findAll()
 

--- a/src/main/kotlin/com/wq/auth/api/domain/member/MemberService.kt
+++ b/src/main/kotlin/com/wq/auth/api/domain/member/MemberService.kt
@@ -4,35 +4,50 @@ import com.wq.auth.api.controller.member.response.LoginResponseDto
 import com.wq.auth.api.domain.email.AuthEmailService
 import com.wq.auth.api.domain.member.entity.AuthProviderEntity
 import com.wq.auth.api.domain.member.entity.MemberEntity
+import com.wq.auth.api.domain.member.entity.refreshTokenEntity
+import com.wq.auth.api.domain.member.error.MemberException
+import com.wq.auth.api.domain.member.error.MemberExceptionCode
 import com.wq.auth.jwt.JwtProperties
 import com.wq.auth.jwt.JwtProvider
 import com.wq.auth.shared.utils.NicknameGenerator
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
 
 @Service
 class MemberService(
     private val authEmailService: AuthEmailService,
     private val memberRepository: MemberRepository,
     private val authProviderRepository: AuthProviderRepository,
+    private val refreshTokenRepository: RefreshTokenRepository,
     private val jwtProvider: JwtProvider,
     private val nicknameGenerator: NicknameGenerator,
-    private val jwtProperties: JwtProperties
+    private val jwtProperties: JwtProperties,
 
 ) {
     @Transactional
     fun emailLogin(email: String): LoginResponseDto {
-        val existingUser = authProviderRepository.findByEmail(email)
-
+        val existingUser = authProviderRepository.findByEmail(email)?.member
+        // 이미 가입된 사용자 → 로그인 처리 및 JWT 발급
         return if (existingUser != null) {
-            // 이미 가입된 사용자 → 로그인 처리 및 JWT 발급
-            val accessToken = jwtProvider.createAccessToken(subject = existingUser.member.id.toString())
-            val refreshToken = jwtProvider.createRefreshToken(subject = existingUser.member.id.toString())
-            //리프레시 토큰 db에 넣어두고 비교 할 때 사용해야함
-            //까보고 그냥 멤버로 줘도 되는거 아닌가
-            //그래도 있어야지..
-            val expiredAt = jwtProperties.accessExp.toMillis() + System.currentTimeMillis()
-            LoginResponseDto.fromTokens(accessToken, refreshToken, expiredAt)
+            val accessToken = jwtProvider.createAccessToken(subject = existingUser.id.toString())
+            val existingRefreshToken = refreshTokenRepository.findByMember(existingUser)
+
+            //이전 리프레시토큰 삭제
+            if (existingRefreshToken != null) {
+                refreshTokenRepository.delete(existingRefreshToken)
+            }
+
+            val (refreshToken, jti) = jwtProvider.createRefreshToken(subject = existingUser.id.toString())
+
+            val now = System.currentTimeMillis()
+            val accessTokenExpiredAt = now + jwtProperties.accessExp.toMillis()
+            val refreshTokenExpiredAt = Instant.now().plus(jwtProperties.refreshExp)
+
+            val refreshTokenEntity = refreshTokenEntity.of(existingUser, jti, refreshTokenExpiredAt)
+            refreshTokenRepository.save(refreshTokenEntity)
+
+            LoginResponseDto.fromTokens(accessToken, refreshToken, accessTokenExpiredAt)
         } else {
             // 없는 이메일 → 회원가입 로직
             signUp(email)
@@ -49,18 +64,27 @@ class MemberService(
             nickname = nicknameGenerator.generate()
             //중복 닉네임인 경우
         } while (memberRepository.existsByNickname(nickname))
-
         val member = MemberEntity.createEmailVerifiedMember(nickname)
-        memberRepository.save(member)
 
-        val provider = AuthProviderEntity.createEmailProvider(member, email)
-        authProviderRepository.save(provider)
+        try {
+            memberRepository.save(member)
+            val provider = AuthProviderEntity.createEmailProvider(member, email)
+            authProviderRepository.save(provider)
+        } catch (ex: Exception) {
+            throw MemberException(MemberExceptionCode.DATABASE_SAVE_FAILED, ex)
+        }
 
         val accessToken = jwtProvider.createAccessToken(subject = member.id.toString())
-        val refreshToken = jwtProvider.createRefreshToken(subject = member.id.toString())
-        val expiredAt = jwtProperties.accessExp.toMillis() + System.currentTimeMillis()
+        val (refreshToken, jti) = jwtProvider.createRefreshToken(subject = member.id.toString())
 
-        return LoginResponseDto.fromTokens(accessToken, refreshToken, expiredAt)
+        val now = System.currentTimeMillis()
+        val accessTokenExpiredAt = now + jwtProperties.accessExp.toMillis()
+        val refreshTokenExpiredAt = Instant.now().plus(jwtProperties.refreshExp)
+
+        val refreshTokenEntity = refreshTokenEntity.of(member, jti, refreshTokenExpiredAt)
+        refreshTokenRepository.save(refreshTokenEntity)
+
+        return LoginResponseDto.fromTokens(accessToken, refreshToken, accessTokenExpiredAt)
     }
 
     fun getAll(): List<MemberEntity> = memberRepository.findAll()

--- a/src/main/kotlin/com/wq/auth/api/domain/member/RefreshTokenRepository.kt
+++ b/src/main/kotlin/com/wq/auth/api/domain/member/RefreshTokenRepository.kt
@@ -1,0 +1,11 @@
+package com.wq.auth.api.domain.member
+
+import com.wq.auth.api.domain.member.entity.MemberEntity
+import com.wq.auth.api.domain.member.entity.refreshTokenEntity
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface RefreshTokenRepository : JpaRepository<refreshTokenEntity, Long> {
+    fun findByJti(token: String): refreshTokenEntity?
+    fun findByMember(member: MemberEntity): refreshTokenEntity?
+    fun deleteByMember(member: MemberEntity): Unit
+}

--- a/src/main/kotlin/com/wq/auth/api/domain/member/entity/AuthProviderEntity.kt
+++ b/src/main/kotlin/com/wq/auth/api/domain/member/entity/AuthProviderEntity.kt
@@ -18,8 +18,8 @@ open class AuthProviderEntity(
     @Column(name = "provider_type", nullable = false)
     open var providerType: ProviderType,
 
-    @Column(name = "provider_id", nullable = false)
-    open var providerId: String,
+    @Column(name = "provider_id", nullable = true)
+    open var providerId: String? = null,
 
     open val email: String = "",
 ) : BaseEntity()

--- a/src/main/kotlin/com/wq/auth/api/domain/member/entity/AuthProviderEntity.kt
+++ b/src/main/kotlin/com/wq/auth/api/domain/member/entity/AuthProviderEntity.kt
@@ -22,4 +22,13 @@ open class AuthProviderEntity(
     open var providerId: String? = null,
 
     open val email: String = "",
-) : BaseEntity()
+) : BaseEntity() {
+    companion object {
+        fun createEmailProvider(member: MemberEntity, email: String) =
+            AuthProviderEntity(
+                member = member,
+                providerType = ProviderType.EMAIL,
+                email = email
+            )
+    }
+}

--- a/src/main/kotlin/com/wq/auth/api/domain/member/entity/MemberEntity.kt
+++ b/src/main/kotlin/com/wq/auth/api/domain/member/entity/MemberEntity.kt
@@ -28,4 +28,12 @@ open class MemberEntity(
     @Column(name = "is_deleted", nullable = false)
     open var isDeleted: Boolean = false,
 
-    ) : BaseEntity()
+    ) : BaseEntity() {
+    companion object {
+        fun createEmailVerifiedMember(nickname: String) =
+            MemberEntity(
+                nickname = nickname,
+                isEmailVerified = true
+            )
+    }
+}

--- a/src/main/kotlin/com/wq/auth/api/domain/member/entity/refreshTokenEntity.kt
+++ b/src/main/kotlin/com/wq/auth/api/domain/member/entity/refreshTokenEntity.kt
@@ -1,0 +1,33 @@
+package com.wq.auth.api.domain.member.entity
+
+import com.wq.auth.shared.entity.BaseEntity
+import jakarta.persistence.*
+import java.time.Instant
+
+@Entity
+@Table(name = "refresh_token")
+class refreshTokenEntity(
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    val member: MemberEntity,
+
+    @Column(nullable = false, unique = true)
+    var jti: String,
+
+    @Column(name = "expired_at", nullable = false)
+    var expiredAt: Instant,
+
+    )  : BaseEntity() {
+    companion object {
+        fun of(member: MemberEntity, jti: String, expiredAt: Instant): refreshTokenEntity {
+            return refreshTokenEntity(
+                member = member,
+                jti = jti,
+                expiredAt = expiredAt
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/wq/auth/api/domain/member/error/MemberException.kt
+++ b/src/main/kotlin/com/wq/auth/api/domain/member/error/MemberException.kt
@@ -1,0 +1,8 @@
+package com.wq.auth.api.domain.member.error
+
+import com.wq.auth.shared.error.ApiException
+
+class MemberException(
+    val memberCode: MemberExceptionCode,
+    cause: Throwable? = null
+) : ApiException(memberCode, cause)

--- a/src/main/kotlin/com/wq/auth/api/domain/member/error/MemberExceptionCode.kt
+++ b/src/main/kotlin/com/wq/auth/api/domain/member/error/MemberExceptionCode.kt
@@ -1,0 +1,10 @@
+package com.wq.auth.api.domain.member.error
+
+import com.wq.auth.shared.error.ApiResponseCode
+
+enum class MemberExceptionCode (
+    override val status: Int,
+    override val message: String
+) : ApiResponseCode {
+    DATABASE_SAVE_FAILED(500, "회원 정보를 저장하는데 실패했습니다.")
+}

--- a/src/main/kotlin/com/wq/auth/jwt/JwtProvider.kt
+++ b/src/main/kotlin/com/wq/auth/jwt/JwtProvider.kt
@@ -60,24 +60,26 @@ class JwtProvider(
      *
      * @param subject 토큰 주체 (opaque: 랜덤 ulid)
      * @param jti 토큰 고유 식별자 (재발급/회전 시 검증용, 기본값: 랜덤 UUID)
-     * @return 생성된 JWT RefreshToken 문자열
+     * @return 생성된 JWT RefreshToken 문자열, jti
      *
      * DB에 jti를 저장해두고 재사용 방지 로직을 구현.
      */
     fun createRefreshToken(
         subject: String,
         jti: String = UUID.randomUUID().toString()
-    ): String {
+    ): Pair<String, String> { // Pair<token, jti>
         val now = Instant.now()
         val exp = Date.from(now.plus(jwtProperties.refreshExp))
 
-        return Jwts.builder()
+        val token = Jwts.builder()
             .subject(subject)
             .id(jti)                 // jti 클레임: RefreshToken 고유 식별자
             .issuedAt(Date.from(now))
             .expiration(exp)
             .signWith(key, Jwts.SIG.HS256)
             .compact()
+
+        return Pair(token, jti)
     }
 
     /**

--- a/src/main/kotlin/com/wq/auth/shared/config/WebConfig.kt
+++ b/src/main/kotlin/com/wq/auth/shared/config/WebConfig.kt
@@ -1,0 +1,19 @@
+package com.wq.auth.shared.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.servlet.config.annotation.CorsRegistry
+import org.springframework.web.servlet.config.annotation.EnableWebMvc
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+@Configuration
+@EnableWebMvc
+class WebConfig : WebMvcConfigurer {
+
+    override fun addCorsMappings(registry: CorsRegistry) {
+        registry.addMapping("/**")
+            .allowedOrigins("http://localhost:5173") // 프론트엔드 주소
+            .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+            .allowedHeaders("*")
+            .allowCredentials(true)
+    }
+}

--- a/src/main/kotlin/com/wq/auth/shared/utils/NicknameGenerator.kt
+++ b/src/main/kotlin/com/wq/auth/shared/utils/NicknameGenerator.kt
@@ -1,0 +1,23 @@
+package com.wq.auth.shared.utils
+
+import org.springframework.stereotype.Component
+
+@Component
+class NicknameGenerator {
+    private val adjectives = listOf(
+        "귀여운", "멋진", "용감한", "재빠른", "행복한",
+        "슬기로운", "웃는", "반짝이는", "든든한", "똑똑한"
+    )
+
+    private val animals = listOf(
+        "토끼", "사자", "호랑이", "여우", "곰",
+        "펭귄", "돌고래", "부엉이", "고양이", "강아지"
+    )
+
+    fun generate(): String {
+        val adj = adjectives.random()
+        val animal = animals.random()
+        val number = (100..999).random()
+        return "$adj$animal$number"
+    }
+}

--- a/src/main/resources/application-jwt.yml
+++ b/src/main/resources/application-jwt.yml
@@ -1,4 +1,4 @@
 jwt:
   secret: ${JWT_SECRET:jwt-secret}
-  access-exp: ${JWT_ACCESS_EXPIRATION:1m}
-  refresh-exp: ${JWT_REFRESH_EXPIRATION:1m}
+  access-exp: ${JWT_ACCESS_TOKEN_EXPIRATION}
+  refresh-exp: ${JWT_REFRESH_TOKEN_EXPIRATION}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,6 +5,7 @@ spring:
 
   application:
     name: auth-BE
+
   mail:
     host: smtp.gmail.com
     port: 587
@@ -17,18 +18,12 @@ spring:
           starttls:
             enable: true
 
-springdoc:
-  api-docs:
-    enabled: true
-  swagger-ui:
-    path: ${SWAGGER_PATH}
-
   datasource:
     url: ${DB_URL:jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE}
     driver-class-name: ${DB_DRIVER:org.h2.Driver}
     username: ${DB_USERNAME:sa}
     password: ${DB_PASSWORD:}
-  
+
   jpa:
     hibernate:
       ddl-auto: ${DDL_AUTO:update}
@@ -48,10 +43,15 @@ springdoc:
       enabled: true
       path: /h2-console
 
+springdoc:
+  api-docs:
+    enabled: true
+  swagger-ui:
+    path: ${SWAGGER_PATH}
+
 app:
   time:
     default-zone: ${APP_DEFAULT_ZONE:Asia/Seoul} # 환경변수 APP_DEFAULT_ZONE이 있으면 그걸 쓰고, 없으면 Asia/Seoul
-
 
 logging:
   level:

--- a/src/test/kotlin/com/wq/auth/unit/AuthMemberServiceTest.kt
+++ b/src/test/kotlin/com/wq/auth/unit/AuthMemberServiceTest.kt
@@ -1,0 +1,228 @@
+package com.wq.auth.unit
+
+import com.wq.auth.api.domain.member.MemberService
+import com.wq.auth.api.domain.member.entity.AuthProviderEntity
+import com.wq.auth.api.domain.member.entity.MemberEntity
+import com.wq.auth.api.domain.member.entity.ProviderType
+import com.wq.auth.jwt.JwtProperties
+import com.wq.auth.jwt.JwtProvider
+import com.wq.auth.api.domain.member.AuthProviderRepository
+import com.wq.auth.api.domain.member.MemberRepository
+import com.wq.auth.shared.utils.NicknameGenerator
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import org.mockito.kotlin.*
+import org.springframework.test.context.ActiveProfiles
+import java.time.Duration
+
+@ActiveProfiles("test")
+class AuthMemberServiceTest : DescribeSpec({
+
+    lateinit var memberService: MemberService
+    lateinit var authProviderRepository: AuthProviderRepository
+    lateinit var memberRepository: MemberRepository
+    lateinit var jwtProvider: JwtProvider
+    lateinit var jwtProperties: JwtProperties
+    lateinit var nicknameGenerator: NicknameGenerator
+
+    beforeEach {
+        authProviderRepository = mock()
+        memberRepository = mock()
+        jwtProvider = mock()
+        jwtProperties = mock()
+        nicknameGenerator = mock()
+
+        memberService = MemberService(
+            authProviderRepository = authProviderRepository,
+            memberRepository = memberRepository,
+            jwtProvider = jwtProvider,
+            jwtProperties = jwtProperties,
+            nicknameGenerator = nicknameGenerator
+        )
+    }
+
+    describe("이메일 로그인 테스트") {
+
+        it("기존 사용자가 이메일로 로그인하면 JWT 토큰을 반환한다") {
+            // given
+            val email = "test@example.com"
+            val memberId = 1L
+            val nickname = "testUser"
+            val accessToken = "access.token.here"
+            val refreshToken = "refresh.token.here"
+            val expiredTime = 1800000L
+
+            val mockMember = mock<MemberEntity>()
+            val mockAuthProvider = mock<AuthProviderEntity>()
+
+            whenever(mockMember.id).thenReturn(memberId)
+            whenever(mockMember.nickname).thenReturn(nickname)
+            whenever(mockAuthProvider.member).thenReturn(mockMember)
+
+            whenever(authProviderRepository.findByEmail(email)).thenReturn(mockAuthProvider)
+            whenever(jwtProvider.createAccessToken(any(), any())).thenReturn(accessToken)
+            whenever(jwtProvider.createRefreshToken(any(), any())).thenReturn(refreshToken)
+            whenever(jwtProperties.accessExp).thenReturn(Duration.ofMillis(expiredTime))
+
+            // when
+            val result = memberService.emailLogin(email)
+
+            // then
+            result.accessToken shouldBe accessToken
+            result.refreshToken shouldBe refreshToken
+            result.expiredAt shouldNotBe null
+
+            verify(authProviderRepository).findByEmail(email)
+            verify(jwtProvider).createAccessToken(any(), any())
+            verify(jwtProvider).createRefreshToken(any(), any())
+        }
+
+        it("존재하지 않는 이메일로 로그인하면 회원가입을 진행한다") {
+            // given
+            val email = "newuser@example.com"
+            val memberId = 2L
+            val nickname = "newUser123"
+            val accessToken = "new.access.token"
+            val refreshToken = "new.refresh.token"
+            val expiredTime = 1800000L
+
+            val mockMember = mock<MemberEntity>()
+
+            whenever(mockMember.id).thenReturn(memberId)
+            whenever(mockMember.nickname).thenReturn(nickname)
+
+            whenever(authProviderRepository.findByEmail(email)).thenReturn(null)
+            whenever(nicknameGenerator.generate()).thenReturn(nickname)
+            whenever(memberRepository.existsByNickname(nickname)).thenReturn(false)
+            whenever(memberRepository.save(any<MemberEntity>())).thenReturn(mockMember)
+            whenever(authProviderRepository.save(any<AuthProviderEntity>())).thenReturn(mock())
+            whenever(jwtProvider.createAccessToken(any(), any())).thenReturn(accessToken)
+            whenever(jwtProvider.createRefreshToken(any(), any())).thenReturn(refreshToken)
+            whenever(jwtProperties.accessExp).thenReturn(Duration.ofMillis(expiredTime))
+
+            // when
+            val result = memberService.emailLogin(email)
+
+            // then
+            result.accessToken shouldBe accessToken
+            result.refreshToken shouldBe refreshToken
+            result.expiredAt shouldNotBe null
+
+            verify(authProviderRepository).findByEmail(email)
+            verify(nicknameGenerator).generate()
+            verify(memberRepository).existsByNickname(nickname)
+            verify(memberRepository).save(any<MemberEntity>())
+            verify(authProviderRepository).save(any<AuthProviderEntity>())
+        }
+    }
+
+    describe("회원가입 테스트") {
+
+        it("새로운 이메일로 회원가입하면 계정을 생성하고 JWT 토큰을 반환한다") {
+            // given
+            val email = "signup@example.com"
+            val memberId = 3L
+            val nickname = "signupUser456"
+            val accessToken = "signup.access.token"
+            val refreshToken = "signup.refresh.token"
+            val expiredTime = 1800000L
+
+            val mockMember = mock<MemberEntity>()
+
+            whenever(mockMember.id).thenReturn(memberId)
+            whenever(mockMember.nickname).thenReturn(nickname)
+
+            whenever(nicknameGenerator.generate()).thenReturn(nickname)
+            whenever(memberRepository.existsByNickname(nickname)).thenReturn(false)
+            whenever(memberRepository.save(any<MemberEntity>())).thenReturn(mockMember)
+            whenever(authProviderRepository.save(any<AuthProviderEntity>())).thenReturn(mock())
+            whenever(jwtProvider.createAccessToken(any(), any())).thenReturn(accessToken)
+            whenever(jwtProvider.createRefreshToken(any(), any())).thenReturn(refreshToken)
+            whenever(jwtProperties.accessExp).thenReturn(Duration.ofMillis(expiredTime))
+
+            // when
+            val result = memberService.signUp(email)
+
+            // then
+            result.accessToken shouldBe accessToken
+            result.refreshToken shouldBe refreshToken
+            result.expiredAt shouldNotBe null
+
+            verify(nicknameGenerator).generate()
+            verify(memberRepository).existsByNickname(nickname)
+            verify(memberRepository).save(any<MemberEntity>())
+            verify(authProviderRepository).save(any<AuthProviderEntity>())
+            verify(jwtProvider).createAccessToken(any(), any())
+            verify(jwtProvider).createRefreshToken(any(), any())
+        }
+
+        it("중복된 닉네임이 생성되면 새로운 닉네임을 재생성한다") {
+            // given
+            val email = "duplicate@example.com"
+            val memberId = 4L
+            val duplicateNickname = "duplicate123"
+            val uniqueNickname = "unique456"
+            val accessToken = "duplicate.access.token"
+            val refreshToken = "duplicate.refresh.token"
+            val expiredTime = 1800000L
+
+            val mockMember = mock<MemberEntity>()
+
+            whenever(mockMember.id).thenReturn(memberId)
+            whenever(mockMember.nickname).thenReturn(uniqueNickname)
+
+            whenever(nicknameGenerator.generate())
+                .thenReturn(duplicateNickname)
+                .thenReturn(uniqueNickname)
+            whenever(memberRepository.existsByNickname(duplicateNickname)).thenReturn(true)
+            whenever(memberRepository.existsByNickname(uniqueNickname)).thenReturn(false)
+            whenever(memberRepository.save(any<MemberEntity>())).thenReturn(mockMember)
+            whenever(authProviderRepository.save(any<AuthProviderEntity>())).thenReturn(mock())
+            whenever(jwtProvider.createAccessToken(any(), any())).thenReturn(accessToken)
+            whenever(jwtProvider.createRefreshToken(any(), any())).thenReturn(refreshToken)
+            whenever(jwtProperties.accessExp).thenReturn(Duration.ofMillis(expiredTime))
+
+            // when
+            val result = memberService.signUp(email)
+
+            // then
+            result.accessToken shouldBe accessToken
+            result.refreshToken shouldBe refreshToken
+
+            verify(nicknameGenerator, times(2)).generate()
+            verify(memberRepository).existsByNickname(duplicateNickname)
+            verify(memberRepository).existsByNickname(uniqueNickname)
+        }
+
+        it("회원가입시 Member 엔티티의 속성이 올바르게 설정된다") {
+            // given
+            val email = "entity@example.com"
+            val nickname = "entityUser"
+
+            val memberCaptor = argumentCaptor<MemberEntity>()
+            val providerCaptor = argumentCaptor<AuthProviderEntity>()
+
+            whenever(nicknameGenerator.generate()).thenReturn(nickname)
+            whenever(memberRepository.existsByNickname(nickname)).thenReturn(false)
+            whenever(memberRepository.save(memberCaptor.capture())).thenAnswer { it.arguments[0] as MemberEntity }
+            whenever(authProviderRepository.save(providerCaptor.capture())).thenAnswer { it.arguments[0] as AuthProviderEntity }
+            whenever(jwtProvider.createAccessToken(any(), any())).thenReturn("token")
+            whenever(jwtProvider.createRefreshToken(any(), any())).thenReturn("refresh")
+            whenever(jwtProperties.accessExp).thenReturn(Duration.ofMillis(1800000L))
+
+            // when
+            memberService.signUp(email)
+
+            // then
+            val savedMember = memberCaptor.firstValue
+            val savedProvider = providerCaptor.firstValue
+
+            savedMember.nickname shouldBe nickname
+            savedMember.isEmailVerified shouldBe true
+            savedProvider.providerType shouldBe ProviderType.EMAIL
+            savedProvider.email shouldBe email
+            savedProvider.member shouldBe savedMember
+        }
+    }
+})

--- a/src/test/kotlin/com/wq/auth/unit/AuthMemberServiceTest.kt
+++ b/src/test/kotlin/com/wq/auth/unit/AuthMemberServiceTest.kt
@@ -1,5 +1,6 @@
 package com.wq.auth.unit
 
+import com.wq.auth.api.domain.email.AuthEmailService
 import com.wq.auth.api.domain.member.MemberService
 import com.wq.auth.api.domain.member.entity.AuthProviderEntity
 import com.wq.auth.api.domain.member.entity.MemberEntity
@@ -8,7 +9,12 @@ import com.wq.auth.jwt.JwtProperties
 import com.wq.auth.jwt.JwtProvider
 import com.wq.auth.api.domain.member.AuthProviderRepository
 import com.wq.auth.api.domain.member.MemberRepository
+import com.wq.auth.api.domain.member.RefreshTokenRepository
+import com.wq.auth.api.domain.member.entity.refreshTokenEntity
+import com.wq.auth.api.domain.member.error.MemberException
+import com.wq.auth.api.domain.member.error.MemberExceptionCode
 import com.wq.auth.shared.utils.NicknameGenerator
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
@@ -20,8 +26,10 @@ import java.time.Duration
 class AuthMemberServiceTest : DescribeSpec({
 
     lateinit var memberService: MemberService
+    lateinit var authEmailService: AuthEmailService
     lateinit var authProviderRepository: AuthProviderRepository
     lateinit var memberRepository: MemberRepository
+    lateinit var refreshTokenRepository: RefreshTokenRepository
     lateinit var jwtProvider: JwtProvider
     lateinit var jwtProperties: JwtProperties
     lateinit var nicknameGenerator: NicknameGenerator
@@ -29,6 +37,8 @@ class AuthMemberServiceTest : DescribeSpec({
     beforeEach {
         authProviderRepository = mock()
         memberRepository = mock()
+        refreshTokenRepository = mock()
+        authEmailService = mock()
         jwtProvider = mock()
         jwtProperties = mock()
         nicknameGenerator = mock()
@@ -36,9 +46,11 @@ class AuthMemberServiceTest : DescribeSpec({
         memberService = MemberService(
             authProviderRepository = authProviderRepository,
             memberRepository = memberRepository,
+            refreshTokenRepository = refreshTokenRepository,
+            authEmailService = authEmailService,
             jwtProvider = jwtProvider,
             jwtProperties = jwtProperties,
-            nicknameGenerator = nicknameGenerator
+            nicknameGenerator = nicknameGenerator,
         )
     }
 
@@ -51,6 +63,7 @@ class AuthMemberServiceTest : DescribeSpec({
             val nickname = "testUser"
             val accessToken = "access.token.here"
             val refreshToken = "refresh.token.here"
+            val jti = "jwt-id-123"
             val expiredTime = 1800000L
 
             val mockMember = mock<MemberEntity>()
@@ -62,8 +75,10 @@ class AuthMemberServiceTest : DescribeSpec({
 
             whenever(authProviderRepository.findByEmail(email)).thenReturn(mockAuthProvider)
             whenever(jwtProvider.createAccessToken(any(), any())).thenReturn(accessToken)
-            whenever(jwtProvider.createRefreshToken(any(), any())).thenReturn(refreshToken)
+            whenever(jwtProvider.createRefreshToken(any(), any())).thenReturn(Pair(refreshToken, jti))
             whenever(jwtProperties.accessExp).thenReturn(Duration.ofMillis(expiredTime))
+            whenever(jwtProperties.refreshExp).thenReturn(Duration.ofDays(7))
+            whenever(refreshTokenRepository.save(any<refreshTokenEntity>())).thenReturn(mock())
 
             // when
             val result = memberService.emailLogin(email)
@@ -76,6 +91,35 @@ class AuthMemberServiceTest : DescribeSpec({
             verify(authProviderRepository).findByEmail(email)
             verify(jwtProvider).createAccessToken(any(), any())
             verify(jwtProvider).createRefreshToken(any(), any())
+            verify(refreshTokenRepository).save(any<refreshTokenEntity>())
+            verifyNoInteractions(authEmailService)
+        }
+
+        it("기존 사용자 로그인 시 이전 refresh token이 있으면 삭제 후 새로 생성한다") {
+            // given
+            val email = "test@example.com"
+            val memberId = 1L
+            val mockMember = mock<MemberEntity>()
+            val mockAuthProvider = mock<AuthProviderEntity>()
+            val existingRefreshToken = mock<refreshTokenEntity>()
+
+            whenever(mockMember.id).thenReturn(memberId)
+            whenever(mockAuthProvider.member).thenReturn(mockMember)
+            whenever(mockAuthProvider.email).thenReturn(email)
+
+            whenever(authProviderRepository.findByEmail(email)).thenReturn(mockAuthProvider)
+            whenever(refreshTokenRepository.findByMember(mockMember)).thenReturn(existingRefreshToken)
+            whenever(jwtProvider.createAccessToken(any(), any())).thenReturn("access-token")
+            whenever(jwtProvider.createRefreshToken(any(), any())).thenReturn(Pair("refresh-token", "jti"))
+            whenever(jwtProperties.accessExp).thenReturn(Duration.ofMinutes(30))
+            whenever(jwtProperties.refreshExp).thenReturn(Duration.ofDays(7))
+
+            // when
+            memberService.emailLogin(email)
+
+            // then
+            verify(refreshTokenRepository).delete(existingRefreshToken)
+            verify(refreshTokenRepository).save(any<refreshTokenEntity>())
         }
 
         it("존재하지 않는 이메일로 로그인하면 회원가입을 진행한다") {
@@ -85,6 +129,7 @@ class AuthMemberServiceTest : DescribeSpec({
             val nickname = "newUser123"
             val accessToken = "new.access.token"
             val refreshToken = "new.refresh.token"
+            val jti = "new-jwt-id"
             val expiredTime = 1800000L
 
             val mockMember = mock<MemberEntity>()
@@ -98,7 +143,7 @@ class AuthMemberServiceTest : DescribeSpec({
             whenever(memberRepository.save(any<MemberEntity>())).thenReturn(mockMember)
             whenever(authProviderRepository.save(any<AuthProviderEntity>())).thenReturn(mock())
             whenever(jwtProvider.createAccessToken(any(), any())).thenReturn(accessToken)
-            whenever(jwtProvider.createRefreshToken(any(), any())).thenReturn(refreshToken)
+            whenever(jwtProvider.createRefreshToken(any(), any())).thenReturn(Pair(refreshToken, jti))
             whenever(jwtProperties.accessExp).thenReturn(Duration.ofMillis(expiredTime))
 
             // when
@@ -126,6 +171,7 @@ class AuthMemberServiceTest : DescribeSpec({
             val nickname = "signupUser456"
             val accessToken = "signup.access.token"
             val refreshToken = "signup.refresh.token"
+            val jti = "signup-jwt-id"
             val expiredTime = 1800000L
 
             val mockMember = mock<MemberEntity>()
@@ -138,7 +184,7 @@ class AuthMemberServiceTest : DescribeSpec({
             whenever(memberRepository.save(any<MemberEntity>())).thenReturn(mockMember)
             whenever(authProviderRepository.save(any<AuthProviderEntity>())).thenReturn(mock())
             whenever(jwtProvider.createAccessToken(any(), any())).thenReturn(accessToken)
-            whenever(jwtProvider.createRefreshToken(any(), any())).thenReturn(refreshToken)
+            whenever(jwtProvider.createRefreshToken(any(), any())).thenReturn(Pair(refreshToken, jti))
             whenever(jwtProperties.accessExp).thenReturn(Duration.ofMillis(expiredTime))
 
             // when
@@ -149,6 +195,7 @@ class AuthMemberServiceTest : DescribeSpec({
             result.refreshToken shouldBe refreshToken
             result.expiredAt shouldNotBe null
 
+            verify(authEmailService).validateEmailFormat(email)
             verify(nicknameGenerator).generate()
             verify(memberRepository).existsByNickname(nickname)
             verify(memberRepository).save(any<MemberEntity>())
@@ -180,7 +227,7 @@ class AuthMemberServiceTest : DescribeSpec({
             whenever(memberRepository.save(any<MemberEntity>())).thenReturn(mockMember)
             whenever(authProviderRepository.save(any<AuthProviderEntity>())).thenReturn(mock())
             whenever(jwtProvider.createAccessToken(any(), any())).thenReturn(accessToken)
-            whenever(jwtProvider.createRefreshToken(any(), any())).thenReturn(refreshToken)
+            whenever(jwtProvider.createRefreshToken(any(), any())).thenReturn(Pair(refreshToken, "jti"))
             whenever(jwtProperties.accessExp).thenReturn(Duration.ofMillis(expiredTime))
 
             // when
@@ -193,6 +240,52 @@ class AuthMemberServiceTest : DescribeSpec({
             verify(nicknameGenerator, times(2)).generate()
             verify(memberRepository).existsByNickname(duplicateNickname)
             verify(memberRepository).existsByNickname(uniqueNickname)
+        }
+
+        it("닉네임 중복이 계속 발생하는 경우를 테스트한다") {
+            // given
+            val email = "test@example.com"
+            val duplicateNickname = "duplicate"
+            val uniqueNickname = "unique"
+
+            val mockMember = mock<MemberEntity>()
+            whenever(mockMember.id).thenReturn(1L)
+            whenever(mockMember.nickname).thenReturn(uniqueNickname)
+
+            whenever(nicknameGenerator.generate())
+                .thenReturn(duplicateNickname, duplicateNickname, duplicateNickname, uniqueNickname)
+            whenever(memberRepository.existsByNickname(duplicateNickname)).thenReturn(true)
+            whenever(memberRepository.existsByNickname(uniqueNickname)).thenReturn(false)
+            whenever(memberRepository.save(any<MemberEntity>())).thenReturn(mockMember)
+            whenever(authProviderRepository.save(any<AuthProviderEntity>())).thenReturn(mock())
+            whenever(jwtProvider.createAccessToken(any(), any())).thenReturn("token")
+            whenever(jwtProvider.createRefreshToken(any(), any())).thenReturn(Pair("refresh", "jti"))
+            whenever(jwtProperties.accessExp).thenReturn(Duration.ofMinutes(30))
+            whenever(jwtProperties.refreshExp).thenReturn(Duration.ofDays(7))
+            whenever(refreshTokenRepository.save(any<refreshTokenEntity>())).thenReturn(mock())
+
+            // when
+            memberService.signUp(email)
+
+            // then
+            verify(nicknameGenerator, times(4)).generate()
+        }
+
+        it("잘못된 이메일 형식으로 회원가입 시 예외가 발생한다") {
+            // given
+            val invalidEmail = "invalid-email"
+            val exception = RuntimeException("Invalid email format")
+
+            whenever(authEmailService.validateEmailFormat(invalidEmail)).thenThrow(exception)
+
+            // when & then
+            shouldThrow<RuntimeException> {
+                memberService.signUp(invalidEmail)
+            }
+
+            verify(authEmailService).validateEmailFormat(invalidEmail)
+            verifyNoInteractions(nicknameGenerator)
+            verifyNoInteractions(memberRepository)
         }
 
         it("회원가입시 Member 엔티티의 속성이 올바르게 설정된다") {
@@ -208,7 +301,7 @@ class AuthMemberServiceTest : DescribeSpec({
             whenever(memberRepository.save(memberCaptor.capture())).thenAnswer { it.arguments[0] as MemberEntity }
             whenever(authProviderRepository.save(providerCaptor.capture())).thenAnswer { it.arguments[0] as AuthProviderEntity }
             whenever(jwtProvider.createAccessToken(any(), any())).thenReturn("token")
-            whenever(jwtProvider.createRefreshToken(any(), any())).thenReturn("refresh")
+            whenever(jwtProvider.createRefreshToken(any(), any())).thenReturn(Pair("refresh", "jti"))
             whenever(jwtProperties.accessExp).thenReturn(Duration.ofMillis(1800000L))
 
             // when
@@ -223,6 +316,25 @@ class AuthMemberServiceTest : DescribeSpec({
             savedProvider.providerType shouldBe ProviderType.EMAIL
             savedProvider.email shouldBe email
             savedProvider.member shouldBe savedMember
+        }
+
+        it("데이터베이스 저장 실패 시 MemberException이 발생한다") {
+            // given
+            val email = "test@example.com"
+            val nickname = "testUser"
+            val dbException = RuntimeException("Database connection failed")
+
+            whenever(nicknameGenerator.generate()).thenReturn(nickname)
+            whenever(memberRepository.existsByNickname(nickname)).thenReturn(false)
+            whenever(memberRepository.save(any<MemberEntity>())).thenThrow(dbException)
+
+            // when & then
+            val exception = shouldThrow<MemberException> {
+                memberService.signUp(email)
+            }
+
+            exception.code shouldBe MemberExceptionCode.DATABASE_SAVE_FAILED
+            exception.cause shouldBe dbException
         }
     }
 })

--- a/src/test/kotlin/com/wq/auth/unit/JwtPropertiesBindingTest.kt
+++ b/src/test/kotlin/com/wq/auth/unit/JwtPropertiesBindingTest.kt
@@ -1,6 +1,6 @@
 package com.wq.demo.unit
 
-import com.wq.demo.jwt.JwtProperties
+import com.wq.auth.jwt.JwtProperties
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.extensions.spring.SpringExtension
 import io.kotest.matchers.shouldBe

--- a/src/test/kotlin/com/wq/auth/unit/JwtProviderTest.kt
+++ b/src/test/kotlin/com/wq/auth/unit/JwtProviderTest.kt
@@ -1,9 +1,9 @@
-package com.wq.demo.unit
+package com.wq.auth.unit
 
-import com.wq.demo.jwt.JwtProperties
-import com.wq.demo.jwt.JwtProvider
-import com.wq.demo.jwt.error.JwtException
-import com.wq.demo.jwt.error.JwtExceptionCode
+import com.wq.auth.jwt.JwtProperties
+import com.wq.auth.jwt.JwtProvider
+import com.wq.auth.jwt.error.JwtException
+import com.wq.auth.jwt.error.JwtExceptionCode
 import io.jsonwebtoken.Jwts
 import io.jsonwebtoken.io.Decoders
 import io.jsonwebtoken.io.Encoders
@@ -70,14 +70,15 @@ class JwtProviderTest : StringSpec({
     }
 
     "RefreshToken을 발급하면 subject 파싱이 정상 동작한다" {
-        val rt = provider.createRefreshToken("user-123")
+        val (rt, jti) = provider.createRefreshToken("user-123")
         provider.getSubject(rt) shouldBe "user-123"
     }
 
     "RefreshToken에는 jti가 포함된다" {
-        val rt = provider.createRefreshToken("user-123")
+        val (rt, jti) = provider.createRefreshToken("user-123")
         val key: SecretKey = Keys.hmacShaKeyFor(Decoders.BASE64.decode(props.secret))
         val claims = Jwts.parser().verifyWith(key).build().parseSignedClaims(rt).payload
+        claims.id shouldBe jti
         (claims.id?.isNotBlank() ?: false).shouldBeTrue()
     }
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

[WQ-59]

## 📝 작업 내용

### 이메일 로그인 구현

- 사용자가 이메일 인증 코드 입력시 바로 이메일 로그인 요청 수행
- 이미 가입된 사용자가 로그인 요청한 경우 로그인 로직 수행
- 가입되지 않은 사용자가 로그인 요청한 경우, 회원가입 로직 수행
 이후 refreshToken, AccessToken 발급 -> refreshToken은 jti를 가져와서 DB에 저장

AccessToken 재발급 요청시 주는 API, 로그아웃 추가 구현 예정입니다 ~


## 📷 스크린샷

### Member Entity 추가 확인

<img width="1025" height="249" alt="스크린샷 2025-08-27 164406" src="https://github.com/user-attachments/assets/a925506c-d3d2-42a6-bb7b-04f0ceb82200" />


### Provider Entity 추가 확인

<img width="858" height="158" alt="스크린샷 2025-08-27 164428" src="https://github.com/user-attachments/assets/a583f67a-ab09-44cd-b832-495b5178e59c" />

### RefeshToken 들어가는 것, 만료 시간 확인

<img width="984" height="312" alt="스크린샷 2025-08-27 164457" src="https://github.com/user-attachments/assets/76a1839d-4eb2-45fd-98e8-0ca4237e5d15" />

### 테스트코드 확인

<img width="1002" height="363" alt="스크린샷 2025-08-27 161559" src="https://github.com/user-attachments/assets/f08f8196-de6b-41c3-aaa9-14a8b18800bb" />


## 💬 리뷰 요구사항

**토큰 처리 방식**
1. dto에 담아 보내고 클라이언트에서 localStorage로 쓰는 방식
- 보안에 취약
2. httpOnly  쿠키로 전달하는 방식
- 배포를 해야만 테스트가 가능 (로컬 테스트가 힘들다)

→ 현재 로그인 모듈은 서버띄우기보단 여기저기 붙여 쓰는 거여서 일단 1번으로 하기로 결정했는데 멘토님의 의견이 궁금합니다 !! (access, refresh 둘 다)
