### PR TITLE
[WQ-140] feat: 소셜(카카오) 로그인 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,6 +43,7 @@ dependencies {
 	implementation("com.google.api-client:google-api-client:2.7.0")
 	implementation("com.google.oauth-client:google-oauth-client-jetty:1.36.0")
 	implementation("com.google.apis:google-api-services-oauth2:v2-rev20200213-2.0.0")
+	implementation("org.springframework.boot:spring-boot-starter-webflux") // For WebClient (Kakao API calls)
 
 	// test
 	testImplementation("org.springframework.boot:spring-boot-starter-test")

--- a/src/main/kotlin/com/wq/auth/api/controller/auth/request/KakaoSocialLoginRequestDto.kt
+++ b/src/main/kotlin/com/wq/auth/api/controller/auth/request/KakaoSocialLoginRequestDto.kt
@@ -1,0 +1,15 @@
+package com.wq.auth.api.controller.auth.request
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotBlank
+
+@Schema(description = "카카오 소셜 로그인 요청 바디")
+data class KakaoSocialLoginRequestDto(
+    @field:NotBlank(message = "authCode는 필수입니다")
+    @field:Schema(description = "카카오 OAuth2에서 받은 인가 코드", example = "9d8fYl7x2zQ...")
+    val authCode: String,
+
+    @field:NotBlank(message = "codeVerifier는 필수입니다")
+    @field:Schema(description = "PKCE 검증용 코드 검증자 (카카오는 선택사항이지만 보안을 위해 권장)", example = "NgAfIySigI...IVxKxbmrpg")
+    val codeVerifier: String
+)

--- a/src/main/kotlin/com/wq/auth/api/external/oauth/KakaoOAuthClient.kt
+++ b/src/main/kotlin/com/wq/auth/api/external/oauth/KakaoOAuthClient.kt
@@ -1,0 +1,185 @@
+package com.wq.auth.api.external.oauth
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.wq.auth.api.domain.auth.entity.ProviderType
+import com.wq.auth.api.external.oauth.dto.KakaoUserInfoResponse
+import com.wq.auth.domain.oauth.OAuthClient
+import com.wq.auth.domain.oauth.OAuthUser
+import com.wq.auth.domain.oauth.error.SocialLoginException
+import com.wq.auth.domain.oauth.error.SocialLoginExceptionCode
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.http.*
+import org.springframework.stereotype.Component
+import org.springframework.util.LinkedMultiValueMap
+import org.springframework.util.MultiValueMap
+import org.springframework.web.client.RestTemplate
+import org.springframework.web.client.HttpClientErrorException
+import org.springframework.web.client.HttpServerErrorException
+
+/**
+ * 카카오 OAuth2 클라이언트
+ * 
+ * 카카오 OAuth2 API와 통신하여 인가 코드를 액세스 토큰으로 교환하고,
+ * 액세스 토큰을 사용하여 사용자 정보를 조회합니다.
+ */
+@Component
+class KakaoOAuthClient(
+    private val kakaoOAuthProperties: KakaoOAuthProperties,
+    private val objectMapper: ObjectMapper
+) : OAuthClient {
+    private val log = KotlinLogging.logger {}
+    private val restTemplate = RestTemplate()
+
+    /**
+     * 인가 코드를 사용하여 액세스 토큰을 획득합니다.
+     * 
+     * @param authorizationCode 카카오로부터 받은 인가 코드
+     * @param codeVerifier PKCE 검증용 코드 검증자 (카카오는 선택사항)
+     * @param redirectUri 리다이렉트 URI (선택사항)
+     * @return 카카오 액세스 토큰
+     * @throws SocialLoginException 토큰 획득 실패 시
+     */
+    fun getAccessToken(authorizationCode: String, codeVerifier: String, redirectUri: String? = null): String {
+        log.info { "카카오 액세스 토큰 요청 시작" }
+        log.info { "redirectUri: ${redirectUri ?: kakaoOAuthProperties.redirectUri}" }
+        
+        val headers = HttpHeaders().apply {
+            contentType = MediaType.APPLICATION_FORM_URLENCODED
+        }
+        
+        val body: MultiValueMap<String, String> = LinkedMultiValueMap<String, String>().apply {
+            add("grant_type", "authorization_code")
+            add("client_id", kakaoOAuthProperties.clientId)
+            if (!kakaoOAuthProperties.clientSecret.isNullOrBlank()) {
+                add("client_secret", kakaoOAuthProperties.clientSecret)
+            }
+            add("redirect_uri", redirectUri ?: kakaoOAuthProperties.redirectUri)
+            add("code", authorizationCode)
+            // 카카오는 PKCE를 지원하지만 선택사항이므로 codeVerifier가 있을 때만 추가
+            if (codeVerifier.isNotBlank()) {
+                add("code_verifier", codeVerifier)
+            }
+        }
+        
+        val request = HttpEntity(body, headers)
+        
+        try {
+            val response = restTemplate.postForEntity(
+                kakaoOAuthProperties.tokenUri,
+                request,
+                String::class.java
+            )
+            
+            if (response.statusCode == HttpStatus.OK && response.body != null) {
+                val tokenResponse = objectMapper.readTree(response.body!!)
+                val accessToken = tokenResponse.get("access_token")?.asText()
+                
+                if (accessToken != null) {
+                    log.info { "카카오 액세스 토큰 획득 성공" }
+                    return accessToken
+                } else {
+                    log.error { "카카오 액세스 토큰이 응답에 없습니다: ${response.body}" }
+                    throw SocialLoginException(SocialLoginExceptionCode.KAKAO_TOKEN_REQUEST_FAILED)
+                }
+            } else {
+                log.error { "카카오 토큰 요청 실패: ${response.statusCode}" }
+                throw SocialLoginException(SocialLoginExceptionCode.KAKAO_TOKEN_REQUEST_FAILED)
+            }
+            
+        } catch (e: HttpClientErrorException) {
+            log.error(e) { "카카오 토큰 요청 클라이언트 오류: ${e.statusCode} - ${e.responseBodyAsString}" }
+            throw SocialLoginException(SocialLoginExceptionCode.KAKAO_INVALID_AUTHORIZATION_CODE, e)
+        } catch (e: HttpServerErrorException) {
+            log.error(e) { "카카오 서버 오류: ${e.statusCode}" }
+            throw SocialLoginException(SocialLoginExceptionCode.KAKAO_TOKEN_REQUEST_FAILED, e)
+        } catch (e: SocialLoginException) {
+            throw e // 이미 SocialLoginException인 경우 그대로 전파
+        } catch (e: Exception) {
+            log.error(e) { "카카오 토큰 요청 중 예상치 못한 오류 발생" }
+            throw SocialLoginException(SocialLoginExceptionCode.KAKAO_TOKEN_REQUEST_FAILED, e)
+        }
+    }
+
+    /**
+     * 액세스 토큰을 사용하여 카카오 사용자 정보를 조회합니다.
+     * 
+     * @param accessToken 카카오 액세스 토큰
+     * @return 카카오 사용자 정보
+     * @throws SocialLoginException 사용자 정보 조회 실패 시
+     */
+    fun getUserInfo(accessToken: String): KakaoUserInfoResponse {
+        log.info { "카카오 사용자 정보 조회 시작" }
+        
+        val headers = HttpHeaders().apply {
+            set("Authorization", "Bearer $accessToken")
+            contentType = MediaType.APPLICATION_JSON
+        }
+        
+        val request = HttpEntity<String>(headers)
+        
+        try {
+            val response = restTemplate.exchange(
+                kakaoOAuthProperties.userInfoUri,
+                HttpMethod.GET,
+                request,
+                String::class.java
+            )
+            
+            if (response.statusCode == HttpStatus.OK && response.body != null) {
+                val userInfo = objectMapper.readValue(response.body!!, KakaoUserInfoResponse::class.java)
+                log.info { "카카오 사용자 정보 조회 성공: ${userInfo.getEmail()}" }
+                return userInfo
+            } else {
+                log.error { "카카오 사용자 정보 조회 실패: ${response.statusCode}" }
+                throw SocialLoginException(SocialLoginExceptionCode.KAKAO_USER_INFO_REQUEST_FAILED)
+            }
+            
+        } catch (e: HttpClientErrorException) {
+            log.error(e) { "카카오 사용자 정보 조회 클라이언트 오류: ${e.statusCode}" }
+            throw SocialLoginException(SocialLoginExceptionCode.KAKAO_USER_INFO_REQUEST_FAILED, e)
+        } catch (e: HttpServerErrorException) {
+            log.error(e) { "카카오 서버 오류: ${e.statusCode}" }
+            throw SocialLoginException(SocialLoginExceptionCode.KAKAO_USER_INFO_REQUEST_FAILED, e)
+        } catch (e: SocialLoginException) {
+            throw e // 이미 SocialLoginException인 경우 그대로 전파
+        } catch (e: Exception) {
+            log.error(e) { "카카오 사용자 정보 조회 중 예상치 못한 오류 발생" }
+            throw SocialLoginException(SocialLoginExceptionCode.KAKAO_USER_INFO_REQUEST_FAILED, e)
+        }
+    }
+
+    /**
+     * OAuthClient 인터페이스 구현: 인가 코드를 사용하여 도메인 사용자 정보를 조회합니다.
+     * 
+     * @param authCode 카카오로부터 받은 인가 코드
+     * @param codeVerifier PKCE 검증용 코드 검증자 (카카오는 선택사항)
+     * @param redirectUri 리다이렉트 URI (선택사항)
+     * @return 도메인 사용자 정보
+     */
+    override fun getUserFromAuthCode(authCode: String, codeVerifier: String, redirectUri: String?): OAuthUser {
+        val accessToken = getAccessToken(authCode, codeVerifier, redirectUri)
+        val kakaoUserInfo = getUserInfo(accessToken)
+        
+        return OAuthUser(
+            providerId = kakaoUserInfo.getProviderId(),
+            email = kakaoUserInfo.getEmail(),
+            verifiedEmail = kakaoUserInfo.isEmailVerified(),
+            name = kakaoUserInfo.getNickname(),
+            givenName = kakaoUserInfo.getNickname(),
+            providerType = ProviderType.KAKAO
+        )
+    }
+
+    /**
+     * 인가 코드를 사용하여 사용자 정보를 직접 조회합니다. (기존 호환성 유지용)
+     * 
+     * @param authorizationCode 카카오로부터 받은 인가 코드
+     * @param codeVerifier PKCE 검증용 코드 검증자 (카카오는 선택사항)
+     * @param redirectUri 리다이렉트 URI (선택사항)
+     * @return 카카오 사용자 정보
+     */
+    fun getUserInfoFromAuthCode(authorizationCode: String, codeVerifier: String, redirectUri: String? = null): KakaoUserInfoResponse {
+        val accessToken = getAccessToken(authorizationCode, codeVerifier, redirectUri)
+        return getUserInfo(accessToken)
+    }
+}

--- a/src/main/kotlin/com/wq/auth/api/external/oauth/KakaoOAuthProperties.kt
+++ b/src/main/kotlin/com/wq/auth/api/external/oauth/KakaoOAuthProperties.kt
@@ -1,0 +1,25 @@
+package com.wq.auth.api.external.oauth
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+/**
+ * 카카오 OAuth2 설정 프로퍼티
+ *
+ * application.yml의 app.oauth.kakao 설정을 바인딩합니다.
+ *
+ * @param clientId 카카오 OAuth2 클라이언트 ID (REST API 키)
+ * @param clientSecret 카카오 OAuth2 클라이언트 시크릿
+ * @param redirectUri 리다이렉트 URI
+ * @param authUri 카카오 OAuth2 인증 URI
+ * @param tokenUri 카카오 OAuth2 토큰 발급 URI
+ * @param userInfoUri 카카오 사용자 정보 조회 URI
+ */
+@ConfigurationProperties(prefix = "app.oauth.kakao")
+data class KakaoOAuthProperties(
+    val clientId: String,
+    val clientSecret: String? = null,
+    val redirectUri: String,
+    val authUri: String,
+    val tokenUri: String,
+    val userInfoUri: String
+)

--- a/src/main/kotlin/com/wq/auth/api/external/oauth/dto/KakaoUserInfoResponse.kt
+++ b/src/main/kotlin/com/wq/auth/api/external/oauth/dto/KakaoUserInfoResponse.kt
@@ -1,0 +1,85 @@
+package com.wq.auth.api.external.oauth.dto
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+/**
+ * 카카오 OAuth2 사용자 정보 응답 DTO
+ * 
+ * 카카오 UserInfo API (/v2/user/me)의 응답을 파싱하기 위한 데이터 클래스입니다.
+ * 
+ * 카카오 API 응답 구조:
+ * {
+ *   "id": 1234567890,
+ *   "kakao_account": {
+ *     "email": "user@example.com",
+ *     "email_needs_agreement": false,
+ *     "is_email_valid": true,
+ *     "is_email_verified": true,
+ *     "profile": {
+ *       "nickname": "홍길동",
+ *       "thumbnail_image_url": "...",
+ *       "profile_image_url": "..."
+ *     }
+ *   }
+ * }
+ */
+data class KakaoUserInfoResponse(
+    @field:JsonProperty("id")
+    val id: Long,
+
+    @field:JsonProperty("kakao_account")
+    val kakaoAccount: KakaoAccount
+) {
+    /**
+     * 닉네임을 생성합니다.
+     * 우선순위: profile.nickname -> email의 @ 앞부분
+     */
+    fun getNickname(): String {
+        return kakaoAccount.profile?.nickname?.takeIf { it.isNotBlank() }
+            ?: kakaoAccount.email?.substringBefore("@") 
+            ?: "카카오사용자$id"
+    }
+
+    /**
+     * 카카오 제공자 ID를 반환합니다.
+     */
+    fun getProviderId(): String = id.toString()
+
+    /**
+     * 이메일을 반환합니다.
+     */
+    fun getEmail(): String = kakaoAccount.email ?: ""
+
+    /**
+     * 이메일 검증 여부를 반환합니다.
+     */
+    fun isEmailVerified(): Boolean = kakaoAccount.isEmailVerified ?: false
+}
+
+data class KakaoAccount(
+    @field:JsonProperty("email")
+    val email: String? = null,
+
+    @field:JsonProperty("email_needs_agreement")
+    val emailNeedsAgreement: Boolean = false,
+
+    @field:JsonProperty("is_email_valid")
+    val isEmailValid: Boolean = false,
+
+    @field:JsonProperty("is_email_verified")
+    val isEmailVerified: Boolean? = false,
+
+    @field:JsonProperty("profile")
+    val profile: KakaoProfile? = null
+)
+
+data class KakaoProfile(
+    @field:JsonProperty("nickname")
+    val nickname: String? = null,
+
+    @field:JsonProperty("thumbnail_image_url")
+    val thumbnailImageUrl: String? = null,
+
+    @field:JsonProperty("profile_image_url")
+    val profileImageUrl: String? = null
+)

--- a/src/main/kotlin/com/wq/auth/shared/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/wq/auth/shared/config/SecurityConfig.kt
@@ -53,6 +53,7 @@ class SecurityConfig(
                         "api/v1/auth/members/refresh", //액세스 토큰 재발급
                         "/api/public/**",         // 공개 API
                         "/api/v1/auth/google/login",
+                        "/api/v1/auth/kakao/login",
                         "/api/v1/auth/**", // 소셜 로그인 API
                         "/actuator/health",       // 헬스체크
                         "/swagger-ui/**",         // Swagger UI

--- a/src/main/kotlin/com/wq/auth/shared/config/WebConfig.kt
+++ b/src/main/kotlin/com/wq/auth/shared/config/WebConfig.kt
@@ -17,6 +17,7 @@ class WebConfig(
         registry.addMapping("/api/**")
             .allowedOrigins(*origins)  // 환경변수로 설정된 특정 origin들만 허용
             .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH")
+            .exposedHeaders("Authorization")
             .allowedHeaders("*")
             .allowCredentials(true)
             .maxAge(3600)

--- a/src/main/resources/application-oauth.yml
+++ b/src/main/resources/application-oauth.yml
@@ -7,5 +7,12 @@ app:
       auth-uri: https://accounts.google.com/o/oauth2/auth
       token-uri: https://oauth2.googleapis.com/token
       user-info-uri: https://www.googleapis.com/oauth2/v2/userinfo
+    kakao:
+      client-id: ${KAKAO_CLIENT_ID}
+      client-secret: ${KAKAO_CLIENT_SECRET:}
+      redirect-uri: ${KAKAO_REDIRECT_URI}
+      auth-uri: https://kauth.kakao.com/oauth/authorize
+      token-uri: https://kauth.kakao.com/oauth/token
+      user-info-uri: https://kapi.kakao.com/v2/user/me
   cors:
     allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost:3000,http://localhost:5173}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) close [WQ-140]

## 📝 작업 내용

기존 구글 OAuth 로그인과 동일한 구조로 카카오 OAuth 로그인 기능을 구현했습니다.
1. 카카오 전용 엔드포인트 추가
- POST /api/v1/auth/kakao/login - 카카오 전용 소셜 로그인
2. OAuth 클라이언트 구현
- `KakaoOAuthClient.kt` - 카카오 API 통신 클라이언트
- `KakaoOAuthProperties.kt `- 카카오 OAuth 설정 프로퍼티
- `KakaoUserInfoResponse.kt `- 카카오 API 응답 DTO
3. 요청/응답 DTO
- `KakaoSocialLoginRequestDto.kt` - 카카오 로그인 요청 DTO
4. 서비스 로직 확장
- `SocialLoginService`에 카카오 로그인 처리 로직 추가
- 기존 회원 확인/신규 회원 생성 로직 재사용
- JWT 토큰 발급 및 RefreshToken 쿠키 설정

[.env 설정해주세요!](https://www.notion.so/277bb18df73c80469fe0d917b39681e5)

## 📷 스크린샷

> 이미지

## 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 명칭
