### PR TITLE
Refactor/WQ-165 email verification login

### DIFF
--- a/src/main/kotlin/com/wq/auth/api/domain/auth/AuthProviderRepository.kt
+++ b/src/main/kotlin/com/wq/auth/api/domain/auth/AuthProviderRepository.kt
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository
 import java.util.Optional
 
 interface AuthProviderRepository : JpaRepository<AuthProviderEntity, Long> {
-    fun findByEmail(email: String): AuthProviderEntity?
+    fun findByEmailAndProviderType(email: String, providerType: ProviderType): AuthProviderEntity?
 
     fun findByProviderIdAndProviderType(
         providerId: String,

--- a/src/main/kotlin/com/wq/auth/api/domain/auth/AuthService.kt
+++ b/src/main/kotlin/com/wq/auth/api/domain/auth/AuthService.kt
@@ -2,6 +2,7 @@ package com.wq.auth.api.domain.auth
 
 import com.wq.auth.api.domain.email.AuthEmailService
 import com.wq.auth.api.domain.auth.entity.AuthProviderEntity
+import com.wq.auth.api.domain.auth.entity.ProviderType
 import com.wq.auth.api.domain.member.entity.MemberEntity
 import com.wq.auth.api.domain.auth.entity.RefreshTokenEntity
 import com.wq.auth.api.domain.member.entity.Role
@@ -38,7 +39,8 @@ class AuthService(
     @Transactional
     fun emailLogin(email: String, deviceId: String?): TokenResult {
         val existingUser =
-            authProviderRepository.findByEmail(email)?.member ?: return signUp(email, deviceId)
+            authProviderRepository.findByEmailAndProviderType(email, ProviderType.EMAIL)?.member
+                ?: return signUp(email, deviceId)
 
         // 이미 가입된 사용자 → 로그인 처리 및 JWT 발급
         val opaqueId = existingUser.opaqueId

--- a/src/main/kotlin/com/wq/auth/api/domain/email/AuthEmailRepository.kt
+++ b/src/main/kotlin/com/wq/auth/api/domain/email/AuthEmailRepository.kt
@@ -4,5 +4,5 @@ import com.wq.auth.api.domain.email.entity.EmailVerificationEntity
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface AuthEmailRepository : JpaRepository<EmailVerificationEntity, String> {
-    fun findByEmail(email: String): EmailVerificationEntity?
+    fun findFirstByEmailOrderByCreatedAtDesc(email: String): EmailVerificationEntity?
 }

--- a/src/main/kotlin/com/wq/auth/api/domain/email/AuthEmailService.kt
+++ b/src/main/kotlin/com/wq/auth/api/domain/email/AuthEmailService.kt
@@ -28,7 +28,6 @@ class AuthEmailService(
         val code = generateRandomCode()
         log.debug("Generated verification code={} for email={}", code, email)
 
-        //TODO 인증번호 5분 제한, 제거시 soft delete
         sendEmail(email, "인증 코드", "인증 코드는 $code 입니다.")
         emailRepository.save(EmailVerificationEntity(email, code))
         log.info("Verification code saved for email={}", email)
@@ -38,7 +37,7 @@ class AuthEmailService(
         log.info("verifyCode() called for email={} with code={}", email, code)
 
         //DB에 x
-        val emailVerificationEntity = emailRepository.findByEmail(email)
+        val emailVerificationEntity = emailRepository.findFirstByEmailOrderByCreatedAtDesc(email)
             ?: throw EmailException(EmailExceptionCode.EMAIL_VERIFICATION_FAILED)
 
         val savedCode = emailVerificationEntity.code

--- a/src/main/kotlin/com/wq/auth/api/domain/email/AuthEmailService.kt
+++ b/src/main/kotlin/com/wq/auth/api/domain/email/AuthEmailService.kt
@@ -9,7 +9,6 @@ import org.slf4j.LoggerFactory
 import org.springframework.mail.javamail.JavaMailSender
 import org.springframework.stereotype.Service
 import java.time.Instant
-import java.time.LocalDateTime
 import java.util.*
 import javax.naming.directory.InitialDirContext
 

--- a/src/main/kotlin/com/wq/auth/api/domain/email/entity/EmailVerificationEntity.kt
+++ b/src/main/kotlin/com/wq/auth/api/domain/email/entity/EmailVerificationEntity.kt
@@ -1,13 +1,23 @@
 package com.wq.auth.api.domain.email.entity
 
+import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.Id
 import jakarta.persistence.Table
+import org.springframework.data.annotation.CreatedDate
+import java.time.Instant
 
 @Entity
 @Table(name = "email_verification")
 data class EmailVerificationEntity(
     @Id
+    @Column(nullable = false, unique = true, length = 255)
     val email: String,
-    val code: String
+
+    @Column(nullable = false, length = 10)
+    val code: String,
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    val createdAt: Instant = Instant.now()
 )

--- a/src/main/kotlin/com/wq/auth/api/domain/email/error/EmailExceptionCode.kt
+++ b/src/main/kotlin/com/wq/auth/api/domain/email/error/EmailExceptionCode.kt
@@ -8,6 +8,7 @@ enum class EmailExceptionCode (
 ) : ApiResponseCode {
     INVALID_EMAIL_FORMAT(400, "올바르지 않은 이메일 형식입니다."),
     EMAIL_VERIFICATION_FAILED(401, "이메일 인증코드가 일치하지 않습니다."),
+    EMAIL_EXPIRED(410, "이메일 인증 시간이 만료되었습니다."),
     EMAIL_NOT_SENDED(500,"이메일 인증코드 전송에 실패했습니다."),
     EMAIL_SERVER_NOT_FOUND(400,"해당 도메인에 메일을 보낼 수 없습니다." ),
     DOMAIN_NOT_FOUND(400,"존재하지 않는 도메인입니다.");

--- a/src/test/kotlin/com/wq/auth/unit/AuthEmailServiceTest.kt
+++ b/src/test/kotlin/com/wq/auth/unit/AuthEmailServiceTest.kt
@@ -59,7 +59,7 @@ class AuthEmailServiceTest : StringSpec({
         val entity = EmailVerificationEntity(email, code)
 
         // repository 동작 모킹
-        whenever(emailRepository.findByEmail(email)).thenReturn(entity)
+        whenever(emailRepository.findFirstByEmailOrderByCreatedAtDesc(email)).thenReturn(entity)
 
         authEmailService.verifyCode(email, code)
     }
@@ -70,7 +70,7 @@ class AuthEmailServiceTest : StringSpec({
         val entity = EmailVerificationEntity(email, code)
 
         // repository 동작 모킹
-        whenever(emailRepository.findByEmail(email)).thenReturn(entity)
+        whenever(emailRepository.findFirstByEmailOrderByCreatedAtDesc(email)).thenReturn(entity)
 
         val exception = shouldThrow<EmailException> {
             authEmailService.verifyCode(email, "wrong-code")

--- a/src/test/kotlin/com/wq/auth/unit/AuthServiceTest.kt
+++ b/src/test/kotlin/com/wq/auth/unit/AuthServiceTest.kt
@@ -76,7 +76,7 @@ class AuthServiceTest : DescribeSpec({
             whenever(mockAuthProvider.email).thenReturn(email)
             whenever(mockAuthProvider.member).thenReturn(mockMember)
 
-            whenever(authProviderRepository.findByEmail(email)).thenReturn(mockAuthProvider)
+            whenever(authProviderRepository.findByEmailAndProviderType(email,ProviderType.EMAIL)).thenReturn(mockAuthProvider)
             whenever(jwtProvider.createAccessToken(any(), any(), any())).thenReturn(accessToken)
             whenever(jwtProvider.createRefreshToken(any(), any())).thenReturn(refreshToken)
             whenever(jwtProvider.getJti(refreshToken)).thenReturn(jti)
@@ -91,7 +91,7 @@ class AuthServiceTest : DescribeSpec({
             result.accessToken shouldBe accessToken
             result.refreshToken shouldBe refreshToken
 
-            verify(authProviderRepository).findByEmail(email)
+            verify(authProviderRepository).findByEmailAndProviderType(email, ProviderType.EMAIL)
             verify(jwtProvider).createAccessToken(any(), any(), any())
             verify(jwtProvider).createRefreshToken(any(), any())
             verify(refreshTokenRepository, times(1)).save(any<RefreshTokenEntity>())
@@ -312,7 +312,7 @@ class AuthServiceTest : DescribeSpec({
         whenever(mockAuthProvider.email).thenReturn(email)
         whenever(mockAuthProvider.member).thenReturn(mockMember)
 
-        whenever(authProviderRepository.findByEmail(email)).thenReturn(mockAuthProvider)
+        whenever(authProviderRepository.findByEmailAndProviderType(email,ProviderType.EMAIL)).thenReturn(mockAuthProvider)
         whenever(jwtProvider.createAccessToken(any(), any(), any())).thenReturn(accessToken)
         whenever(jwtProvider.createRefreshToken(any(), any())).thenReturn(refreshToken)
         whenever(jwtProvider.getJti(refreshToken)).thenReturn(jti)
@@ -328,7 +328,7 @@ class AuthServiceTest : DescribeSpec({
         result.refreshToken shouldBe refreshToken
         
 
-        verify(authProviderRepository).findByEmail(email)
+        verify(authProviderRepository).findByEmailAndProviderType(email, ProviderType.EMAIL)
         verify(jwtProvider).createAccessToken(any(), any(), any())
         verify(jwtProvider).createRefreshToken(any(), any())
         verify(refreshTokenRepository).save(any<RefreshTokenEntity>())
@@ -350,7 +350,7 @@ class AuthServiceTest : DescribeSpec({
         whenever(mockAuthProvider.member).thenReturn(mockMember)
         whenever(mockAuthProvider.email).thenReturn(email)
 
-        whenever(authProviderRepository.findByEmail(email)).thenReturn(mockAuthProvider)
+        whenever(authProviderRepository.findByEmailAndProviderType(email,ProviderType.EMAIL)).thenReturn(mockAuthProvider)
         whenever(refreshTokenRepository.findActiveByMemberAndDeviceId(mockMember, deviceId)).thenReturn(existingRefreshToken)
         whenever(jwtProvider.createAccessToken(any(), any(), any())).thenReturn("access-token")
         whenever(jwtProvider.createRefreshToken(any(), any())).thenReturn("refresh-token")
@@ -382,7 +382,7 @@ class AuthServiceTest : DescribeSpec({
         whenever(mockMember.nickname).thenReturn(nickname)
         whenever(mockMember.opaqueId).thenReturn(opaqueId)
 
-        whenever(authProviderRepository.findByEmail(email)).thenReturn(null)
+        whenever(authProviderRepository.findByEmailAndProviderType(email,ProviderType.EMAIL)).thenReturn(null)
         whenever(nicknameGenerator.generate()).thenReturn(nickname)
         whenever(memberRepository.existsByNickname(nickname)).thenReturn(false)
         whenever(memberRepository.save(any<MemberEntity>())).thenReturn(mockMember)
@@ -401,7 +401,7 @@ class AuthServiceTest : DescribeSpec({
         result.refreshToken shouldBe refreshToken
         
 
-        verify(authProviderRepository).findByEmail(email)
+        verify(authProviderRepository).findByEmailAndProviderType(email,ProviderType.EMAIL)
         verify(nicknameGenerator).generate()
         verify(memberRepository).existsByNickname(nickname)
         verify(memberRepository).save(any<MemberEntity>())


### PR DESCRIPTION
## #️⃣ 연관된 이슈

[WQ-165]

## 📝 작업 내용


1. 이메일 로그인 인증 5분 제한 추가
- 커스텀 에러 추가 (410)

2. 이메일 로그인시, 가입된 사용자인지 찾는 로직 수정
- 전 : 이메일 -> 후 : 이메일 + ProviderType

## 📷 스크린샷

### 인증 5분 넘어서 오류난 경우

<img width="1252" height="157" alt="스크린샷 2025-10-01 114541" src="https://github.com/user-attachments/assets/1db65e01-c4e1-401d-89f5-bdb65721c521" />

## 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 명칭


[WQ-165]: https://growgrammers.atlassian.net/browse/WQ-165?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ