### PR TITLE
refactor: WQ-175 쿠키 설정 환경 변수로 분리

### DIFF
--- a/src/main/kotlin/com/wq/auth/api/controller/auth/AuthController.kt
+++ b/src/main/kotlin/com/wq/auth/api/controller/auth/AuthController.kt
@@ -20,6 +20,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.servlet.http.HttpServletResponse
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpHeaders
 import org.springframework.http.ResponseCookie
 import org.springframework.web.bind.annotation.*
@@ -30,6 +31,12 @@ class AuthController(
     private val authService: AuthService,
     private val emailService: AuthEmailService,
     private val jwtProperties: JwtProperties,
+
+    @Value("\${app.cookie.secure:false}")
+    private val cookieSecure: Boolean,
+
+    @Value("\${app.cookie.same-site:Strict}")
+    private val cookieSameSite: String,
 ) {
 
     @Operation(
@@ -75,12 +82,10 @@ class AuthController(
         if (clientType == "web") {
             val refreshCookie = ResponseCookie.from("refreshToken", newRefreshToken)
                 .httpOnly(true)
-                //.secure(true) 배포시
-                .secure(false)
+                .secure(cookieSecure)
                 .path("/")
                 .maxAge(jwtProperties.refreshExp.toSeconds())
-                //.sameSite("None") 배포시
-                .sameSite("Lax")
+                .sameSite(cookieSameSite)
                 .build()
             response.addHeader("Set-Cookie", refreshCookie.toString())
 
@@ -134,12 +139,10 @@ class AuthController(
         if (clientType == "web") {
             val refreshCookie = ResponseCookie.from("refreshToken", "")
                 .httpOnly(true)
-                //.secure(true) 배포시
-                .secure(false)
+                .secure(cookieSecure)
                 .path("/")
                 .maxAge(0)
-                //.sameSite("None") 배포시
-                .sameSite("Lax")
+                .sameSite(cookieSameSite)
                 .build()
             response.addHeader("Set-Cookie", refreshCookie.toString())
 
@@ -209,14 +212,13 @@ class AuthController(
         response.setHeader(HttpHeaders.AUTHORIZATION, "Bearer ${accessToken}")
 
         if (clientType == "web") {
+
             val refreshCookie = ResponseCookie.from("refreshToken", newRefreshToken)
                 .httpOnly(true)
-                //.secure(true) 배포시
-                .secure(false)
+                .secure(cookieSecure)
                 .path("/")
                 .maxAge(jwtProperties.refreshExp.toSeconds())
-                //.sameSite("None") 배포시
-                .sameSite("Lax")
+                .sameSite(cookieSameSite)
                 .build()
             response.addHeader("Set-Cookie", refreshCookie.toString())
             

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -30,3 +30,8 @@ logging:
     org.hibernate.SQL: debug
     org.hibernate.type.descriptor.sql.BasicBinder: trace
     org.springframework.orm.jpa: debug
+
+app:
+  cookie:
+    secure: false
+    same-site: Lax

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -23,3 +23,8 @@ logging:
   level:
     org.hibernate.SQL: warn
     org.springframework.orm.jpa: info
+
+app:
+  cookie:
+    secure: true
+    same-site: Strict

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,5 +29,3 @@ springdoc:
 app:
   time:
     default-zone: ${APP_DEFAULT_ZONE:Asia/Seoul}
-  cookie:
-    same-site: ${APP_COOKIE_SAME_SITE:Strict}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

[WQ-175]

## 📝 작업 내용

1. 리프레시토큰 쿠키에 넣는 설정 로컬/서버 차이 환경변수로 분리

## 📷 스크린샷

> 이미지

## 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 명칭


[WQ-175]: https://growgrammers.atlassian.net/browse/WQ-175?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ