### PR TITLE
[Fix] 토큰 재발급 로직 변경 및 로그인 시 토큰 쿠키에 담는 것으로 변경

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,6 @@ on:
     branches:
       - main
       - dev
-      - feat/internal-server-api
 
 jobs:
   build-and-push:

--- a/src/main/kotlin/com/wq/auth/api/controller/auth/AuthController.kt
+++ b/src/main/kotlin/com/wq/auth/api/controller/auth/AuthController.kt
@@ -84,14 +84,12 @@ class AuthController(
             deviceId = req.deviceId,
         )
 
-        response.setHeader(HttpHeaders.AUTHORIZATION, "Bearer ${accessToken}")
+        val accessTokenCookie = cookieFactory.createAccessTokenCookie(accessToken)
+        val refreshTokenCookie = cookieFactory.createRefreshTokenCookie(newRefreshToken)
+        response.addHeader(HttpHeaders.SET_COOKIE, accessTokenCookie.toString())
+        response.addHeader(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString())
 
         if (clientType == "web") {
-            val accessTokenCookie = cookieFactory.createAccessTokenCookie(accessToken)
-            val refreshTokenCookie = cookieFactory.createRefreshTokenCookie(newRefreshToken)
-            response.addHeader(HttpHeaders.SET_COOKIE, accessTokenCookie.toString())
-            response.addHeader(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString())
-
             return CommonResponse.success(message = "로그인에 성공했습니다.", data = null)
         }
 
@@ -127,7 +125,7 @@ class AuthController(
             - 인증 코드 삭제
             
             **인증 요구사항:**
-            - Authorization 헤더에 유효한 JWT 토큰 필요
+            - `accessToken` HttpOnly 쿠키에 유효한 JWT 토큰 필요
             - 토큰은 재발급되지 않으며 기존 토큰 그대로 사용
         """
     )
@@ -229,7 +227,7 @@ class AuthController(
             ),
             ApiResponse(
                 responseCode = "400",
-                description = "잘못된 요청, 인증 토큰이 없음, Authorization 헤더는 'Bearer <token>' 형식이어야 합니다.",
+                description = "잘못된 요청, 인증 토큰이 없음",
                 content = [Content(
                     mediaType = "application/json",
                     schema = Schema(implementation = CommonResponse::class)
@@ -257,29 +255,33 @@ class AuthController(
     @PostMapping("/api/v1/auth/members/refresh")
     @PublicApi
     fun refreshAccessToken(
-        @CookieValue(name = "refreshToken", required = false) refreshToken: String,
+        request: HttpServletRequest, // 헤더/쿠키에서 이전 AT를 읽기 위함
+        @CookieValue(name = "refreshToken", required = false) refreshToken: String?,
         @RequestHeader("X-Client-Type") clientType: String,
         response: HttpServletResponse,
         @RequestBody req: RefreshAccessTokenRequestDto?,
     ): CommonResponse<RefreshAccessTokenResponseDto> {
 
-        val currentRefreshToken : String?
-        if(clientType == "web") {
-            currentRefreshToken = refreshToken
+        val currentRefreshToken : String? = if(clientType == "web") {
+            refreshToken
         } else {
-            currentRefreshToken = req?.refreshToken
+            req?.refreshToken
         }
+
+        if (currentRefreshToken.isNullOrBlank()) {
+            throw JwtException(JwtExceptionCode.TOKEN_MISSING)
+        }
+
         val (accessToken, newRefreshToken) = authService.refreshAccessToken(
-            currentRefreshToken!!, req?.deviceId,
+            currentRefreshToken, req?.deviceId
         )
-        response.setHeader(HttpHeaders.AUTHORIZATION, "Bearer ${accessToken}")
+
+        val accessTokenCookie = cookieFactory.createAccessTokenCookie(accessToken)
+        val refreshTokenCookie = cookieFactory.createRefreshTokenCookie(newRefreshToken)
+        response.addHeader(HttpHeaders.SET_COOKIE, accessTokenCookie.toString())
+        response.addHeader(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString())
 
         if (clientType == "web") {
-            val accessTokenCookie = cookieFactory.createAccessTokenCookie(accessToken)
-            val refreshTokenCookie = cookieFactory.createRefreshTokenCookie(newRefreshToken)
-            response.addHeader(HttpHeaders.SET_COOKIE, accessTokenCookie.toString())
-            response.addHeader(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString())
-
             return CommonResponse.success(message = "AccessToken 재발급에 성공했습니다.", data = null)
         }
 
@@ -297,10 +299,14 @@ class AuthController(
             API Gateway 연동용 엔드포인트입니다. 요청에 포함된 Access Token을 검증하고, 성공 시 응답 헤더에 사용자 정보를 담아 반환합니다.
             
             **토큰 탐색 우선순위:**
-            1. `accessToken` HttpOnly 쿠키 (웹 클라이언트 전용)
-               - 쿠키가 존재하면 Authorization 헤더는 완전히 무시됩니다.
+            1. `accessToken` HttpOnly 쿠키
                - 쿠키 값이 비어있으면 401을 반환합니다.
-            2. `Authorization: Bearer <token>` 헤더 (앱 클라이언트 / 쿠키가 없을 때만 사용)
+            2. `Authorization: Bearer <token>` 헤더 (쿠키가 없을 때만 사용)
+            
+            **토큰 반환 방식:**
+            - Access Token: HttpOnly 쿠키(`accessToken`)
+            - Refresh Token: HttpOnly 쿠키(`refreshToken`)
+            - 기존 Authorization 헤더는 더 이상 사용하지 않습니다.
             
             **사일런트 리프레시 (Silent Refresh):**
             - Access Token이 만료되었거나 남은 유효 시간이 5분(300초) 미만이면 `refreshToken` 쿠키로 자동 재발급을 시도합니다.
@@ -309,14 +315,13 @@ class AuthController(
             
             **성공 응답 헤더:**
             - `X-User-Id`: 사용자 UUID (opaqueId)
-            - `X-Auth-Provider`: 대표 연동 제공자 (EMAIL, GOOGLE, KAKAO, NAVER 중 하나, 연동된 경우)
         """
     )
     @ApiResponses(
         value = [
             ApiResponse(
                 responseCode = "200",
-                description = "인트로스펙트 성공 (X-User-Id, X-Auth-Provider 헤더 포함). AT가 임박한 경우 Set-Cookie로 새 토큰도 포함됩니다.",
+                description = "인트로스펙트 성공 (X-User-Id 헤더 포함). AT가 임박한 경우 Set-Cookie로 새 토큰도 포함됩니다.",
                 content = [Content(schema = Schema(implementation = CommonResponse::class))]
             ),
             ApiResponse(
@@ -350,7 +355,7 @@ class AuthController(
             }
 
             try {
-                // 만료된 AT에서도 claims를 읽어 deviceId를 전달합니다.
+                // 만료된 AT에서도 claims를 읽어 deviceId를 추출합니다.
                 val claims = jwtProvider.getClaimsEvenIfExpired(token)
                 val deviceId = claims["deviceId"] as? String
 
@@ -372,9 +377,6 @@ class AuthController(
         }
 
         response.setHeader("X-User-Id", opaqueId)
-        memberService.getPrimaryProvider(opaqueId)?.let { provider ->
-            response.setHeader("X-Auth-Provider", provider.name)
-        }
     }
 
     /**

--- a/src/main/kotlin/com/wq/auth/api/controller/auth/AuthController.kt
+++ b/src/main/kotlin/com/wq/auth/api/controller/auth/AuthController.kt
@@ -9,18 +9,24 @@ import com.wq.auth.api.controller.auth.response.RefreshAccessTokenResponseDto
 import com.wq.auth.api.domain.auth.AuthService
 import com.wq.auth.api.domain.email.AuthEmailService
 import com.wq.auth.api.domain.member.MemberService
+import com.wq.auth.security.JwtAuthenticationFilter
 import com.wq.auth.security.annotation.AuthenticatedApi
 import com.wq.auth.security.annotation.PublicApi
+import com.wq.auth.security.jwt.JwtProvider
+import com.wq.auth.security.jwt.error.JwtException
+import com.wq.auth.security.jwt.error.JwtExceptionCode
 import com.wq.auth.security.principal.PrincipalDetails
 import com.wq.auth.shared.config.CookieFactory
 import com.wq.auth.shared.rateLimiter.annotation.RateLimit
 import com.wq.auth.web.common.response.CommonResponse
+import io.github.oshai.kotlinlogging.KotlinLogging
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import jakarta.validation.Valid
 import org.springframework.http.HttpHeaders
@@ -35,7 +41,9 @@ class AuthController(
     private val emailService: AuthEmailService,
     private val memberService: MemberService,
     private val cookieFactory: CookieFactory,
+    private val jwtProvider: JwtProvider,
 ) {
+    private val log = KotlinLogging.logger {}
 
     @Operation(
         summary = "이메일 로그인",
@@ -284,37 +292,96 @@ class AuthController(
     }
 
     @Operation(
-        summary = "토큰 인트로스펙트",
+        summary = "토큰 introspect",
         description = """
-            API Gateway 연동용. Authorization 헤더의 JWT를 검증하고, 성공 시 응답 헤더에 다음을 담아 반환합니다.
-            - X-User-Id: 사용자 UUID (opaqueId)
-            - X-Auth-Provider: 대표 연동 제공자 (EMAIL, GOOGLE, KAKAO, NAVER 중 하나, 연동된 경우)
+            API Gateway 연동용 엔드포인트입니다. 요청에 포함된 Access Token을 검증하고, 성공 시 응답 헤더에 사용자 정보를 담아 반환합니다.
+            
+            **토큰 탐색 우선순위:**
+            1. `accessToken` HttpOnly 쿠키 (웹 클라이언트 전용)
+               - 쿠키가 존재하면 Authorization 헤더는 완전히 무시됩니다.
+               - 쿠키 값이 비어있으면 401을 반환합니다.
+            2. `Authorization: Bearer <token>` 헤더 (앱 클라이언트 / 쿠키가 없을 때만 사용)
+            
+            **사일런트 리프레시 (Silent Refresh):**
+            - Access Token이 만료되었거나 남은 유효 시간이 5분(300초) 미만이면 `refreshToken` 쿠키로 자동 재발급을 시도합니다.
+            - 재발급 성공 시 응답의 `Set-Cookie`로 새 토큰을 내려주며 FE/사용자 개입이 불필요합니다.
+            - 재발급 실패(리프레시 토큰 만료·오류) 시 기존 쿠키를 모두 삭제하고 401을 반환합니다.
+            
+            **성공 응답 헤더:**
+            - `X-User-Id`: 사용자 UUID (opaqueId)
+            - `X-Auth-Provider`: 대표 연동 제공자 (EMAIL, GOOGLE, KAKAO, NAVER 중 하나, 연동된 경우)
         """
     )
     @ApiResponses(
         value = [
             ApiResponse(
                 responseCode = "200",
-                description = "인트로스펙트 성공 (X-User-Id, X-Auth-Provider 헤더 포함)",
+                description = "인트로스펙트 성공 (X-User-Id, X-Auth-Provider 헤더 포함). AT가 임박한 경우 Set-Cookie로 새 토큰도 포함됩니다.",
                 content = [Content(schema = Schema(implementation = CommonResponse::class))]
             ),
             ApiResponse(
                 responseCode = "401",
-                description = "인증되지 않은 사용자",
+                description = "토큰 없음, 빈 쿠키, 리프레시 토큰 만료·오류 등 인증 실패. 쿠키가 존재하던 경우 해당 쿠키는 제거됩니다.",
                 content = [Content(schema = Schema(implementation = CommonResponse::class))]
             )
         ]
     )
     @RateLimit(limit = 60, duration = 1, timeUnit = TimeUnit.MINUTES)
-    @AuthenticatedApi
+    @PublicApi
     @GetMapping("/api/v1/auth/introspect")
     fun introspect(
+        request: HttpServletRequest,
         response: HttpServletResponse,
-        @AuthenticationPrincipal principalDetails: PrincipalDetails
     ) {
-        response.setHeader("X-User-Id", principalDetails.opaqueId)
-        memberService.getPrimaryProvider(principalDetails.opaqueId)?.let { provider ->
+        val token = JwtAuthenticationFilter.extractToken(request)
+        // 쿠키·헤더 모두 없거나, accessToken 쿠키가 빈 값인 경우 401
+        if (token.isNullOrBlank()) {
+            throw JwtException(JwtExceptionCode.TOKEN_MISSING)
+        }
+
+        // AT가 만료(-1)되었거나 남은 시간이 5분(300초) 미만이면 사일런트 리프레시 시도
+        val remainingSeconds = jwtProvider.getRemainingTimeSeconds(token)
+        val opaqueId: String = if (remainingSeconds < 300) {
+            val refreshToken = request.cookies?.firstOrNull { it.name == "refreshToken" }?.value
+
+            if (refreshToken.isNullOrBlank()) {
+                clearAuthCookies(response)
+                throw JwtException(JwtExceptionCode.TOKEN_MISSING)
+            }
+
+            try {
+                // 만료된 AT에서도 claims를 읽어 deviceId를 전달합니다.
+                val claims = jwtProvider.getClaimsEvenIfExpired(token)
+                val deviceId = claims["deviceId"] as? String
+
+                val tokenResult = authService.refreshAccessToken(refreshToken, deviceId)
+
+                response.addHeader(HttpHeaders.SET_COOKIE, cookieFactory.createAccessTokenCookie(tokenResult.accessToken).toString())
+                response.addHeader(HttpHeaders.SET_COOKIE, cookieFactory.createRefreshTokenCookie(tokenResult.refreshToken).toString())
+
+                log.debug { "사일런트 리프레시 성공 (remainingSeconds=$remainingSeconds)" }
+
+                jwtProvider.getOpaqueId(tokenResult.accessToken)
+            } catch (e: Exception) {
+                log.warn { "사일런트 리프레시 실패: ${e.message}" }
+                clearAuthCookies(response)
+                throw JwtException(JwtExceptionCode.EXPIRED)
+            }
+        } else {
+            jwtProvider.getOpaqueId(token)
+        }
+
+        response.setHeader("X-User-Id", opaqueId)
+        memberService.getPrimaryProvider(opaqueId)?.let { provider ->
             response.setHeader("X-Auth-Provider", provider.name)
         }
+    }
+
+    /**
+     * accessToken, refreshToken HttpOnly 쿠키를 즉시 만료시킵니다.
+     */
+    private fun clearAuthCookies(response: HttpServletResponse) {
+        response.addHeader(HttpHeaders.SET_COOKIE, cookieFactory.expireAccessTokenCookie().toString())
+        response.addHeader(HttpHeaders.SET_COOKIE, cookieFactory.expireRefreshTokenCookie().toString())
     }
 }

--- a/src/main/kotlin/com/wq/auth/api/controller/auth/SocialLoginController.kt
+++ b/src/main/kotlin/com/wq/auth/api/controller/auth/SocialLoginController.kt
@@ -42,7 +42,7 @@ class SocialLoginController(
 ) {
 
     /**
-     * 범용 소셜 로그인 처리
+     * 소셜 로그인 처리
      *
      * 프론트엔드에서 소셜 제공자로부터 받은 인가 코드를 사용하여
      * 사용자 정보를 조회하고 JWT 토큰을 발급합니다.
@@ -61,8 +61,8 @@ class SocialLoginController(
             - 프론트엔드 환경별로 다른 URI 사용 가능 (개발/스테이징/프로덕션)
             
             **토큰 반환 방식:**
-            - Access Token: Authorization 헤더에 Bearer 방식으로 반환
-            - Refresh Token: HttpOnly 쿠키로 설정 (XSS 공격 방지)
+            - Access Token: HttpOnly 쿠키(`accessToken`)로 설정
+            - Refresh Token: HttpOnly 쿠키(`refreshToken`)로 설정 (XSS 공격 방지)
             
             **지원 소셜 제공자:**
             - GOOGLE: Google OAuth2
@@ -74,7 +74,7 @@ class SocialLoginController(
         value = [
             ApiResponse(
                 responseCode = "200",
-                description = "로그인 성공 - Authorization 헤더에 Bearer 토큰, HttpOnly 쿠키에 리프레시 토큰 설정",
+                description = "로그인 성공 - HttpOnly 쿠키에 액세스 토큰 및 리프레시 토큰 설정",
                 content = [Content(schema = Schema(implementation = CommonResponse::class))]
             ),
             ApiResponse(
@@ -132,8 +132,9 @@ class SocialLoginController(
             - 프론트엔드 환경별로 다른 URI 사용 가능
             
             **토큰 반환 방식:**
-            - Access Token: Authorization 헤더에 Bearer 방식으로 반환
-            - Refresh Token: HttpOnly 쿠키로 설정 (XSS 공격 방지)
+            - Access Token: HttpOnly 쿠키(`accessToken`)로 설정
+            - Refresh Token: HttpOnly 쿠키(`refreshToken`)로 설정 (XSS 공격 방지)
+            - 기존 Authorization 헤더 방식은 보안 및 웹 친화적 설계를 위해 제거되었습니다.
             
             **쿠키 설정:**
             - HttpOnly: JavaScript 접근 불가 (XSS 방지)
@@ -145,7 +146,7 @@ class SocialLoginController(
         value = [
             ApiResponse(
                 responseCode = "200",
-                description = "Google 로그인 성공 - Authorization 헤더에 Bearer 토큰, HttpOnly 쿠키에 리프레시 토큰 설정",
+                description = "Google 로그인 성공 - HttpOnly 쿠키에 액세스 토큰 및 리프레시 토큰 설정",
                 content = [Content(schema = Schema(implementation = CommonResponse::class))]
             ),
             ApiResponse(
@@ -208,15 +209,16 @@ class SocialLoginController(
             - 보안 강화를 위해 사용 권장
             
             **토큰 반환 방식:**
-            - Access Token: Authorization 헤더에 Bearer 방식으로 반환
-            - Refresh Token: HttpOnly 쿠키로 설정 (XSS 공격 방지)
+            - Access Token: HttpOnly 쿠키(`accessToken`)로 설정
+            - Refresh Token: HttpOnly 쿠키(`refreshToken`)로 설정 (XSS 공격 방지)
+            - 기존 Authorization 헤더 방식은 보안 및 웹 친화적 설계를 위해 제거되었습니다.
         """
     )
     @ApiResponses(
         value = [
             ApiResponse(
                 responseCode = "200",
-                description = "카카오 로그인 성공 - Authorization 헤더에 Bearer 토큰, HttpOnly 쿠키에 리프레시 토큰 설정",
+                description = "카카오 로그인 성공 - HttpOnly 쿠키에 액세스 토큰 및 리프레시 토큰 설정",
                 content = [Content(schema = Schema(implementation = CommonResponse::class))]
             ),
             ApiResponse(
@@ -276,8 +278,9 @@ class SocialLoginController(
             - 프론트엔드 환경별로 다른 URI 사용 가능
             
             **토큰 반환 방식:**
-            - Access Token: Authorization 헤더에 Bearer 방식으로 반환
-            - Refresh Token: HttpOnly 쿠키로 설정 (XSS 공격 방지)
+            - Access Token: HttpOnly 쿠키(`accessToken`)로 설정
+            - Refresh Token: HttpOnly 쿠키(`refreshToken`)로 설정 (XSS 공격 방지)
+            - 기존 Authorization 헤더 방식은 보안 및 웹 친화적 설계를 위해 제거되었습니다.
             
             **쿠키 설정:**
             - HttpOnly: JavaScript 접근 불가 (XSS 방지)
@@ -289,7 +292,7 @@ class SocialLoginController(
         value = [
             ApiResponse(
                 responseCode = "200",
-                description = "Naver 로그인 성공 - Authorization 헤더에 Bearer 토큰, HttpOnly 쿠키에 리프레시 토큰 설정",
+                description = "Naver 로그인 성공 - HttpOnly 쿠키에 액세스 토큰 및 리프레시 토큰 설정",
                 content = [Content(schema = Schema(implementation = CommonResponse::class))]
             ),
             ApiResponse(
@@ -347,7 +350,7 @@ class SocialLoginController(
             - 연동 계정이 있는 경우: 두 계정 자동 병합 (기존 회원 정보 유지)
             
             **인증 요구사항:**
-            - Authorization 헤더에 유효한 JWT 토큰 필요
+            - `accessToken` HttpOnly 쿠키에 유효한 JWT 토큰 필요
             - 토큰은 재발급되지 않으며 기존 토큰 그대로 사용
         """
     )
@@ -422,7 +425,7 @@ class SocialLoginController(
             - 보안 강화를 위해 사용 권장
             
             **인증 요구사항:**
-            - Authorization 헤더에 유효한 JWT 토큰 필요
+            - `accessToken` HttpOnly 쿠키에 유효한 JWT 토큰 필요
             - 토큰은 재발급되지 않으며 기존 토큰 그대로 사용
         """
     )
@@ -497,7 +500,7 @@ class SocialLoginController(
             - 프론트엔드에서 생성한 state 값을 전달해야 함
             
             **인증 요구사항:**
-            - Authorization 헤더에 유효한 JWT 토큰 필요
+            - `accessToken` HttpOnly 쿠키에 유효한 JWT 토큰 필요
             - 토큰은 재발급되지 않으며 기존 토큰 그대로 사용
         """
     )
@@ -546,7 +549,7 @@ class SocialLoginController(
     }
 
     /**
-     * AccessToken/RefreshToken을 HttpOnly 쿠키 및 Authorization 헤더로 설정합니다.
+     * AccessToken/RefreshToken을 HttpOnly 쿠키로 설정합니다.
      *
      * @param response HTTP 응답 객체
      * @param accessToken 액세스 토큰
@@ -562,6 +565,5 @@ class SocialLoginController(
 
         response.addHeader(HttpHeaders.SET_COOKIE, accessTokenCookie.toString())
         response.addHeader(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString())
-        response.setHeader(HttpHeaders.AUTHORIZATION, "Bearer $accessToken")
     }
 }

--- a/src/main/kotlin/com/wq/auth/security/JwtAuthenticationFilter.kt
+++ b/src/main/kotlin/com/wq/auth/security/JwtAuthenticationFilter.kt
@@ -22,6 +22,31 @@ class JwtAuthenticationFilter(
     companion object {
         private const val AUTHORIZATION_HEADER = "Authorization"
         private const val BEARER_PREFIX = "Bearer "
+
+        /**
+         * HTTP 요청에서 JWT 토큰을 추출합니다.
+         *
+         * 토큰 우선순위:
+         * 1. `accessToken` HttpOnly 쿠키 (웹 클라이언트 전용)
+         *    - 쿠키가 존재하면 헤더는 완전히 무시됩니다.
+         * 2. `Authorization: Bearer <token>` 헤더 (앱 클라이언트 / 쿠키 없을 때만 사용)
+         *
+         * @return 토큰 문자열, 아무것도 없으면 null
+         */
+        fun extractToken(request: HttpServletRequest): String? {
+            val accessTokenCookie = request.cookies?.firstOrNull { it.name == "accessToken" }
+
+            if (accessTokenCookie != null) {
+                return accessTokenCookie.value
+            }
+
+            val authorizationHeader = request.getHeader(AUTHORIZATION_HEADER)
+            return if (!authorizationHeader.isNullOrBlank() && authorizationHeader.startsWith(BEARER_PREFIX)) {
+                authorizationHeader.substring(BEARER_PREFIX.length)
+            } else {
+                null
+            }
+        }
     }
 
     override fun doFilterInternal(
@@ -29,27 +54,18 @@ class JwtAuthenticationFilter(
         response: HttpServletResponse,
         filterChain: FilterChain
     ) {
-
-        val httpReq = request as HttpServletRequest
-        println("Request URI: ${httpReq.requestURI}")
-
         try {
-            // Authorization 헤더에서 JWT 토큰 추출
-            val token = extractTokenFromRequest(request)
-
-            if (token != null) {
-                // JWT 토큰 유효성 검증
+            val token = extractToken(request)
+            if (!token.isNullOrBlank()) {
                 jwtProvider.validateOrThrow(token)
 
-                // 토큰에서 사용자 정보 추출
-                val principalDetails = extractPrincipalDetails(token)
+                val principalDetails = PrincipalDetails(jwtProvider.getOpaqueId(token))
 
-                // Spring Security 인증 객체 생성 및 설정
                 // todo : TokenService로 분리 필요.
                 val authentication = UsernamePasswordAuthenticationToken(
-                    principalDetails,       // principal: PrincipalDetails 객체
-                    null,                  // credentials: 비밀번호 (JWT에서는 불필요)
-                    principalDetails.authorities  // authorities: 사용자 권한
+                    principalDetails,
+                    null,
+                    principalDetails.authorities
                 )
                 SecurityContextHolder.getContext().authentication = authentication
             }
@@ -59,45 +75,6 @@ class JwtAuthenticationFilter(
             log.debug(e) { "JWT 필터 처리 중 예외 발생: ${e.message}" }
         }
 
-        // 다음 필터로 진행
         filterChain.doFilter(request, response)
-    }
-
-    /**
-     * HTTP 요청에서 JWT 토큰을 추출합니다.
-     *
-     * @param request HTTP 요청 객체
-     * @return 추출된 JWT 토큰 문자열, 없으면 null
-     */
-    private fun extractTokenFromRequest(request: HttpServletRequest): String? {
-        // 1. accessToken HttpOnly 쿠키 우선 사용 (웹 클라이언트)
-        val cookieToken = request.cookies
-            ?.firstOrNull { it.name == "accessToken" }
-            ?.value
-
-        if (!cookieToken.isNullOrBlank()) {
-            return cookieToken
-        }
-
-        // 2. Authorization 헤더(Bearer) fallback (앱 및 과도기 웹 클라이언트)
-        val authorizationHeader = request.getHeader(AUTHORIZATION_HEADER)
-
-        return if (!authorizationHeader.isNullOrBlank() && authorizationHeader.startsWith(BEARER_PREFIX)) {
-            authorizationHeader.substring(BEARER_PREFIX.length)
-        } else {
-            null
-        }
-    }
-
-    /**
-     * JWT 토큰에서 PrincipalDetails 객체를 생성합니다.
-     *
-     * @param token JWT 토큰
-     * @return PrincipalDetails 객체
-     */
-    private fun extractPrincipalDetails(token: String): PrincipalDetails {
-        val opaqueId = jwtProvider.getOpaqueId(token)
-
-        return PrincipalDetails(opaqueId)
     }
 }

--- a/src/main/kotlin/com/wq/auth/security/jwt/JwtProvider.kt
+++ b/src/main/kotlin/com/wq/auth/security/jwt/JwtProvider.kt
@@ -3,6 +3,7 @@ package com.wq.auth.security.jwt
 import com.wq.auth.security.jwt.error.JwtException
 import com.wq.auth.security.jwt.error.JwtExceptionCode
 import com.github.f4b6a3.uuid.UuidCreator
+import io.jsonwebtoken.Claims
 import io.jsonwebtoken.ExpiredJwtException
 import io.jsonwebtoken.Jwts
 import io.jsonwebtoken.MalformedJwtException
@@ -105,6 +106,41 @@ class JwtProvider(
             .build().parseSignedClaims(token)
             .payload
             .expiration.toInstant()
+
+    /**
+     * 토큰의 남은 유효 시간을 초 단위로 반환합니다.
+     *
+     * - 양수: 아직 유효하며 해당 초만큼 남음
+     * - 음수(-1): 이미 만료된 토큰 (서명 자체는 유효)
+     * - 서명 오류, 위조 등 구조적으로 유효하지 않은 토큰은 [JwtException] 을 던집니다.
+     */
+    fun getRemainingTimeSeconds(token: String): Long {
+        return try {
+            val expiration = Jwts.parser().verifyWith(key).build().parseSignedClaims(token).payload.expiration
+            (expiration.time - System.currentTimeMillis()) / 1000
+        } catch (e: ExpiredJwtException) {
+            -1L
+        } catch (t: Throwable) {
+            throw JwtException(mapToCode(t), t)
+        }
+    }
+
+    /**
+     * 만료 여부와 관계없이 토큰의 클레임을 추출합니다.
+     *
+     * 만료된 토큰이라도 서명이 유효하다면 클레임을 반환합니다.
+     * 이는 사일런트 리프레시 시 만료된 AT에서 opaqueId/deviceId를 읽어야 할 때 사용합니다.
+     * 서명이 위조되거나 형식이 잘못된 경우에는 [JwtException] 을 던집니다.
+     */
+    fun getClaimsEvenIfExpired(token: String): Claims {
+        return try {
+            Jwts.parser().verifyWith(key).build().parseSignedClaims(token).payload
+        } catch (e: ExpiredJwtException) {
+            e.claims
+        } catch (t: Throwable) {
+            throw JwtException(mapToCode(t), t)
+        }
+    }
 
     /**
      * 유효성 검사(예외 던짐) – 표준 에러로 변환

--- a/src/main/kotlin/com/wq/auth/shared/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/wq/auth/shared/config/SecurityConfig.kt
@@ -62,7 +62,7 @@ class SecurityConfig(
                         "/actuator/health",       // 헬스체크
                         "/swagger-ui/**",         // Swagger UI
                         "/v3/api-docs/**",        // OpenAPI 문서
-                        "/h2-console/**"          // H2 콘솔 (개발용)
+                        "/api/v1/auth/introspect"
                     ).permitAll()
                     
                     // 나머지 모든 요청은 인증 필요 (세부 권한은 @PreAuthorize로 처리)


### PR DESCRIPTION
## 📝 작업 내용

### 정리


구분 | Access Token (AT) | Refresh Token (RT) 
-- | -- | -- 
변경 전 | Authorization 헤더 (Bearer <AT>) | HttpOnly 쿠키 refreshToken 
변경 후 | HttpOnly 쿠키 accessToken | HttpOnly 쿠키 refreshToken




### 변경된 토큰 재발급 로직

1. 🛡️ 토큰 정책 및 보안 강화

  - 쿠키 중심 인증: 기존 Authorization 헤더 반환 방식을 제거하고, accessToken과 refreshToken을 모두 HttpOnly 쿠키에 담아 반환하도록 통일했습니다. (XSS 공격 방지 및 FE 구현 단순화)
  - 토큰 추출 우선순위: API Gateway 필터(JwtAuthenticationFilter)에서 쿠키를 최우선으로 확인하며, 쿠키가 없을 때만 헤더(Authorization: Bearer)를 확인하는 폴백 로직을 적용했습니다.
  - 엄격한 검증: accessToken 쿠키가 존재하지만 값이 비어있는 경우, 유효하지 않은 세션으로 간주하여 즉시 401 Unauthorized를 반환하도록 개선했습니다.

2. 🔄 사일런트 리프레시 (Silent Refresh) 구현

- 자동 갱신: introspect API 호출 시 Access Token(AT)의 만료 시간이 5분(300초) 미만으로 남았거나 이미 만료된 경우, 유효한 리프레시 토큰이 있다면 자동으로 새 AT/RT를 발급합니다.
- FE/사용자 무중단: 재발급된 토큰은 응답의 Set-Cookie 헤더를 통해 자동으로 브라우저에 저장되므로, 프론트엔드에서 별도의 리프레시 로직(인터셉터 등)을 짤 필요가 없습니다
- 강제 로그아웃 로직: 리프레시 토큰이 만료되었거나 재발급에 실패할 경우, 기존에 남아있던 모든 쿠키를 즉시 만료(Max-Age=0)시켜 세션을 깔끔하게 정리하고 401을 반환합니다.

```mermaid
graph TD
    Start["인트로스펙트 호출 (/api/v1/auth/introspect)"] --> ExtractToken["토큰 추출 (JwtAuthenticationFilter.extractToken)"]
    
    subgraph Extraction["[1] 토큰 추출 우선순위"]
        ExtractToken --> CheckCookie{"accessToken 쿠키 존재?"}
        CheckCookie -- "예" --> UseCookie["쿠키 값 사용 (헤더 무시)"]
        CheckCookie -- "아니오" --> CheckHeader{"Authorization 헤더 존재?"}
        CheckHeader -- "예" --> UseHeader["헤더 값 사용"]
        CheckHeader -- "아니오" --> NoToken["토큰 없음 결정"]
    end

    UseCookie --> ValidateEmpty
    UseHeader --> ValidateEmpty
    NoToken --> Fail401["401 Unauthorized 반환"]

    subgraph Validation["[2] 검증 및 재발급 판단"]
        ValidateEmpty --> IsEmpty{"토큰 값이 비어있음?"}
        IsEmpty -- "예" --> Fail401
        IsEmpty -- "아니오" --> CheckTime{"만료됨 OR 남은 시간 < 5분?"}
        
        CheckTime -- "예 (갱신 필요)" --> CheckRT{"refreshToken 쿠키 존재?"}
        CheckRT -- "아니오" --> ClearCookies["모든 쿠키 삭제 (Max-Age=0)"]
        CheckRT -- "예" --> TryRefresh["AuthService.refreshAccessToken 시도"]
        
        TryRefresh -- "성공" --> SetCookies["새 AT/RT 쿠키 응답 설정 (Set-Cookie)"]
        TryRefresh -- "실패 (RT만료/오류)" --> ClearCookies
        
        CheckTime -- "아니오 (유효함)" --> Success["유저 UUID 추출 (opaqueId)"]
    end

    ClearCookies --> Fail401
    SetCookies --> Success
    Success --> Final["응답 헤더에 X-User-Id 설정 후 종료"]
```