### PR TITLE
fix: alpha/prod 쿠키 SameSite를 Strict에서 Lax로 변경

### DIFF
--- a/src/main/resources/application-alpha.yml
+++ b/src/main/resources/application-alpha.yml
@@ -26,4 +26,4 @@ app:
   cookie:
     domain: ${APP_COOKIE_DOMAIN}
     secure: true
-    same-site: Strict
+    same-site: Lax

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -32,4 +32,4 @@ app:
   cookie:
     domain: ${APP_COOKIE_DOMAIN}
     secure: true
-    same-site: Strict
+    same-site: Lax


### PR DESCRIPTION
## Summary
로그인 성공 후 `?redirect=%2Fdashboard&expired=1`로 튕기는 문제 해결 — alpha/prod 쿠키 SameSite를 Strict → Lax로 변경합니다.

## Changes
- `application-alpha.yml`, `application-prod.yml`: `app.cookie.same-site` Strict → Lax
- 소셜 로그인(OAuth) 콜백처럼 cross-site에서 시작된 최상위 네비게이션에는 Strict 쿠키가 실리지 않아, SSR/미들웨어 인증 판단 시 로그인 직후에도 미인증으로 처리되던 문제를 해결
- Lax는 최상위 GET 네비게이션에 쿠키를 허용하면서 POST 등 cross-site 요청은 계속 차단하므로 CSRF 방어는 대부분 유지됨
- 코드 변경 없음 — `CookieFactory`는 `app.cookie.same-site` 설정값을 그대로 사용 (`AuthControllerIntegrationTest`는 프로퍼티를 자체 주입하므로 영향 없음)

## Testing Notes
- 배포 후 브라우저 쿠키 삭제 → 재로그인 → `Set-Cookie`에 `SameSite=Lax` 확인
- 소셜 로그인 콜백 복귀 직후 dashboard 진입 시 expired 리다이렉트가 발생하지 않는지 확인
- 기존 사용자는 쿠키 재발급(재로그인 또는 silent refresh) 후부터 적용됨