### PR TITLE
feat: 회원탈퇴(계정 즉시 삭제) API + SB4·kotest6 테스트 인프라 마이그레이션

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -71,7 +71,11 @@ dependencies {
 	testImplementation("io.kotest:kotest-assertions-core:$kotestVersion")
 	testImplementation("io.kotest:kotest-assertions-json:$kotestVersion")
 	testImplementation("io.kotest:kotest-property:$kotestVersion")
-	testImplementation("io.kotest.extensions:kotest-extensions-spring:1.1.3")
+	// kotest 6.x용 Spring 확장(메인 io.kotest 그룹, kotest 버전과 정렬)
+	testImplementation("io.kotest:kotest-extensions-spring:$kotestVersion")
+
+	// Spring Boot 4: WebMvcTest / AutoConfigureMockMvc 는 별도 모듈로 분리
+	testImplementation("org.springframework.boot:spring-boot-webmvc-test")
 
 	// Mockito-Kotlin
 	testImplementation("org.mockito.kotlin:mockito-kotlin:5.4.0")

--- a/src/main/kotlin/com/wq/auth/api/controller/auth/AuthController.kt
+++ b/src/main/kotlin/com/wq/auth/api/controller/auth/AuthController.kt
@@ -84,12 +84,11 @@ class AuthController(
             deviceId = req.deviceId,
         )
 
-        val accessTokenCookie = cookieFactory.createAccessTokenCookie(accessToken)
-        val refreshTokenCookie = cookieFactory.createRefreshTokenCookie(newRefreshToken)
-        response.addHeader(HttpHeaders.SET_COOKIE, accessTokenCookie.toString())
-        response.addHeader(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString())
-
         if (clientType == "web") {
+            val accessTokenCookie = cookieFactory.createAccessTokenCookie(accessToken)
+            val refreshTokenCookie = cookieFactory.createRefreshTokenCookie(newRefreshToken)
+            response.addHeader(HttpHeaders.SET_COOKIE, accessTokenCookie.toString())
+            response.addHeader(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString())
             return CommonResponse.success(message = "로그인에 성공했습니다.", data = null)
         }
 
@@ -276,12 +275,11 @@ class AuthController(
             currentRefreshToken, req?.deviceId
         )
 
-        val accessTokenCookie = cookieFactory.createAccessTokenCookie(accessToken)
-        val refreshTokenCookie = cookieFactory.createRefreshTokenCookie(newRefreshToken)
-        response.addHeader(HttpHeaders.SET_COOKIE, accessTokenCookie.toString())
-        response.addHeader(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString())
-
         if (clientType == "web") {
+            val accessTokenCookie = cookieFactory.createAccessTokenCookie(accessToken)
+            val refreshTokenCookie = cookieFactory.createRefreshTokenCookie(newRefreshToken)
+            response.addHeader(HttpHeaders.SET_COOKIE, accessTokenCookie.toString())
+            response.addHeader(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString())
             return CommonResponse.success(message = "AccessToken 재발급에 성공했습니다.", data = null)
         }
 

--- a/src/main/kotlin/com/wq/auth/api/controller/member/MemberController.kt
+++ b/src/main/kotlin/com/wq/auth/api/controller/member/MemberController.kt
@@ -5,6 +5,7 @@ import com.wq.auth.api.domain.member.entity.MemberEntity
 import com.wq.auth.api.domain.member.MemberService
 import com.wq.auth.security.annotation.AuthenticatedApi
 import com.wq.auth.security.principal.PrincipalDetails
+import com.wq.auth.shared.config.CookieFactory
 import com.wq.auth.shared.rateLimiter.annotation.RateLimit
 import com.wq.auth.web.common.response.CommonResponse
 import io.swagger.v3.oas.annotations.Operation
@@ -13,6 +14,8 @@ import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.http.HttpHeaders
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.*
 import java.util.concurrent.TimeUnit
@@ -21,6 +24,7 @@ import java.util.concurrent.TimeUnit
 @RestController
 class MemberController(
     private val memberService: MemberService,
+    private val cookieFactory: CookieFactory,
 ) {
 
     @Operation(
@@ -73,10 +77,38 @@ class MemberController(
     fun create(@RequestBody member: MemberEntity): CommonResponse<MemberEntity> =
         CommonResponse.success("회원 생성 성공", memberService.create(member))
 
-    @DeleteMapping("/api/v1/members/{id}")
-    fun delete(@PathVariable id: Long): CommonResponse<Void> {
-        memberService.delete(id)
-        return CommonResponse.success("회원 삭제 성공")
+    @Operation(
+        summary = "회원 탈퇴",
+        description = "인증된 본인 계정을 즉시 하드 삭제합니다. 소셜 연동 정보 및 리프레시 토큰도 함께 삭제됩니다."
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "회원 탈퇴 성공",
+                content = [Content(schema = Schema(implementation = CommonResponse::class))]
+            ),
+            ApiResponse(
+                responseCode = "401",
+                description = "인증 실패 또는 로그인 필요",
+                content = [Content(schema = Schema(implementation = CommonResponse::class))]
+            )
+        ]
+    )
+    @RateLimit(limit = 5, duration = 1, timeUnit = TimeUnit.MINUTES)
+    @DeleteMapping("/api/v1/auth/members/me")
+    @AuthenticatedApi
+    fun withdraw(
+        @AuthenticationPrincipal principalDetail: PrincipalDetails,
+        @RequestHeader("X-Client-Type") clientType: String,
+        response: HttpServletResponse,
+    ): CommonResponse<Void> {
+        memberService.withdraw(principalDetail.opaqueId, clientType)
+        if (clientType == "web") {
+            response.addHeader(HttpHeaders.SET_COOKIE, cookieFactory.expireAccessTokenCookie().toString())
+            response.addHeader(HttpHeaders.SET_COOKIE, cookieFactory.expireRefreshTokenCookie().toString())
+        }
+        return CommonResponse.success("회원 탈퇴 성공")
     }
 
     @PutMapping("/api/v1/members/{id}/nickname")

--- a/src/main/kotlin/com/wq/auth/api/domain/auth/AuthProviderRepository.kt
+++ b/src/main/kotlin/com/wq/auth/api/domain/auth/AuthProviderRepository.kt
@@ -4,6 +4,8 @@ import com.wq.auth.api.domain.auth.entity.AuthProviderEntity
 import com.wq.auth.api.domain.member.entity.MemberEntity
 import com.wq.auth.api.domain.auth.entity.ProviderType
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.transaction.annotation.Transactional
 
 interface AuthProviderRepository : JpaRepository<AuthProviderEntity, Long> {
     fun findByEmailAndProviderType(email: String, providerType: ProviderType): AuthProviderEntity?
@@ -19,4 +21,8 @@ interface AuthProviderRepository : JpaRepository<AuthProviderEntity, Long> {
         member: MemberEntity,
         providerType: ProviderType
     ): AuthProviderEntity?
+
+    @Modifying
+    @Transactional
+    fun deleteByMember(member: MemberEntity)
 }

--- a/src/main/kotlin/com/wq/auth/api/domain/auth/RefreshTokenRepository.kt
+++ b/src/main/kotlin/com/wq/auth/api/domain/auth/RefreshTokenRepository.kt
@@ -30,4 +30,8 @@ interface RefreshTokenRepository : JpaRepository<RefreshTokenEntity, Long> {
     @Query("SELECT r FROM RefreshTokenEntity r WHERE r.member = :member AND r.deviceId = :deviceId AND r.deletedAt IS NULL")
     fun findActiveByMemberAndDeviceId(@Param("member") member: MemberEntity, @Param("deviceId") deviceId: String?): RefreshTokenEntity?
 
+    @Modifying
+    @Transactional
+    fun deleteByMember(member: MemberEntity)
+
 }

--- a/src/main/kotlin/com/wq/auth/api/domain/member/MemberService.kt
+++ b/src/main/kotlin/com/wq/auth/api/domain/member/MemberService.kt
@@ -1,18 +1,23 @@
 package com.wq.auth.api.domain.member
 
 import com.wq.auth.api.domain.auth.AuthProviderRepository
+import com.wq.auth.api.domain.auth.RefreshTokenRepository
 import com.wq.auth.api.domain.auth.entity.ProviderType
 import com.wq.auth.api.domain.member.entity.MemberEntity
+import com.wq.auth.api.domain.member.entity.MemberWithdrawalAuditEntity
 import com.wq.auth.api.domain.member.error.MemberException
 import com.wq.auth.api.domain.member.error.MemberExceptionCode
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
 
 @Service
 class MemberService(
     private val memberRepository: MemberRepository,
     private val authProviderRepository: AuthProviderRepository,
+    private val refreshTokenRepository: RefreshTokenRepository,
+    private val memberWithdrawalAuditRepository: MemberWithdrawalAuditRepository,
     ) {
 
     companion object {
@@ -77,7 +82,28 @@ class MemberService(
 
     fun create(member: MemberEntity): MemberEntity = memberRepository.save(member)
 
-    fun delete(id: Long) = memberRepository.deleteById(id)
+    @Transactional
+    fun withdraw(opaqueId: String, sourceClient: String?) {
+        val member = memberRepository.findByOpaqueId(opaqueId).orElse(null)
+        if (member == null) {
+            log.warn("[MemberService] 이미 탈퇴한 회원 - opaqueId={}", opaqueId)
+            return
+        }
+
+        memberWithdrawalAuditRepository.save(
+            MemberWithdrawalAuditEntity(
+                opaqueId = opaqueId,
+                withdrawnAt = Instant.now(),
+                sourceClient = sourceClient,
+            )
+        )
+
+        refreshTokenRepository.deleteByMember(member)
+        authProviderRepository.deleteByMember(member)
+        memberRepository.delete(member)
+
+        log.info("[MemberService] 회원 탈퇴 완료 - opaqueId={}, sourceClient={}", opaqueId, sourceClient)
+    }
 
     fun updateNickname(id: Long, newNickname: String): MemberEntity? {
         val member = memberRepository.findById(id).orElse(null)

--- a/src/main/kotlin/com/wq/auth/api/domain/member/MemberWithdrawalAuditRepository.kt
+++ b/src/main/kotlin/com/wq/auth/api/domain/member/MemberWithdrawalAuditRepository.kt
@@ -1,0 +1,6 @@
+package com.wq.auth.api.domain.member
+
+import com.wq.auth.api.domain.member.entity.MemberWithdrawalAuditEntity
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface MemberWithdrawalAuditRepository : JpaRepository<MemberWithdrawalAuditEntity, Long>

--- a/src/main/kotlin/com/wq/auth/api/domain/member/entity/MemberWithdrawalAuditEntity.kt
+++ b/src/main/kotlin/com/wq/auth/api/domain/member/entity/MemberWithdrawalAuditEntity.kt
@@ -1,0 +1,21 @@
+package com.wq.auth.api.domain.member.entity
+
+import jakarta.persistence.*
+import java.time.Instant
+
+@Entity
+@Table(name = "member_withdrawal_audit")
+class MemberWithdrawalAuditEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0,
+
+    @Column(name = "opaque_id", nullable = false, length = 36)
+    val opaqueId: String,
+
+    @Column(name = "withdrawn_at", nullable = false)
+    val withdrawnAt: Instant,
+
+    @Column(name = "source_client", nullable = true, length = 50)
+    val sourceClient: String? = null,
+)

--- a/src/main/kotlin/com/wq/auth/shared/time/JacksonTimeConfig.kt
+++ b/src/main/kotlin/com/wq/auth/shared/time/JacksonTimeConfig.kt
@@ -1,13 +1,14 @@
 package com.wq.auth.shared.time
 
-import com.fasterxml.jackson.core.JsonGenerator
-import com.fasterxml.jackson.databind.DeserializationContext
-import com.fasterxml.jackson.databind.JsonDeserializer
-import com.fasterxml.jackson.databind.JsonSerializer
-import com.fasterxml.jackson.databind.SerializerProvider
-import com.fasterxml.jackson.databind.module.SimpleModule
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import tools.jackson.core.JsonGenerator
+import tools.jackson.core.JsonParser
+import tools.jackson.databind.DeserializationContext
+import tools.jackson.databind.SerializationContext
+import tools.jackson.databind.ValueDeserializer
+import tools.jackson.databind.ValueSerializer
+import tools.jackson.databind.module.SimpleModule
 import java.time.Instant
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
@@ -19,8 +20,8 @@ private val ISO_WITH_SECONDS: DateTimeFormatter =
 /** Instant -> ISO-8601(+offset)로 ZoneProvider 기준 변환 */
 class InstantToZoneSerializer(
     private val zoneProvider: ZoneProvider
-) : JsonSerializer<Instant>() { // Instant -> JSON 문자열로 변환하는 클래스
-    override fun serialize(value: Instant?, gen: JsonGenerator, serializers: SerializerProvider) {
+) : ValueSerializer<Instant>() {
+    override fun serialize(value: Instant?, gen: JsonGenerator, ctxt: SerializationContext) {
         if (value == null) { gen.writeNull(); return }
         val offset = value
             .atZone(ZoneOffset.UTC)
@@ -31,9 +32,9 @@ class InstantToZoneSerializer(
 }
 
 /** ISO 문자열 -> Instant (요청 바디 수신 시) */
-class InstantFromIsoDeserializer : JsonDeserializer<Instant>() {
-    override fun deserialize(p: com.fasterxml.jackson.core.JsonParser, ctxt: DeserializationContext): Instant {
-        val s = p.text
+class InstantFromIsoDeserializer : ValueDeserializer<Instant>() {
+    override fun deserialize(p: JsonParser, ctxt: DeserializationContext): Instant {
+        val s = p.getString()
         return runCatching { OffsetDateTime.parse(s).toInstant() }
             .getOrElse { Instant.parse(s) }
     }
@@ -41,6 +42,9 @@ class InstantFromIsoDeserializer : JsonDeserializer<Instant>() {
 
 /**
  * Jackson에 커스텀 Serializer/Deserializer를 등록하는 설정 클래스
+ *
+ * Spring Boot 4는 Jackson 3.x(tools.jackson.*)를 사용하므로,
+ * ValueSerializer / ValueDeserializer 및 tools.jackson.databind.module.SimpleModule을 사용합니다.
  */
 @Configuration
 class JacksonTimeConfig(private val zoneProvider: ZoneProvider) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -45,7 +45,7 @@ springdoc:
   api-docs:
     enabled: true
   swagger-ui:
-    path: ${SWAGGER_PATH}
+    path: ${SWAGGER_PATH:/swagger-ui.html}
 
 app:
   time:

--- a/src/test/kotlin/com/wq/auth/integration/AuthControllerIntegrationTest.kt
+++ b/src/test/kotlin/com/wq/auth/integration/AuthControllerIntegrationTest.kt
@@ -3,27 +3,31 @@ package com.wq.auth.integration
 import com.wq.auth.api.controller.auth.AuthController
 import com.wq.auth.api.domain.email.AuthEmailService
 import com.wq.auth.api.domain.auth.AuthService
+import com.wq.auth.api.domain.member.MemberService
 import com.wq.auth.security.jwt.JwtProperties
 import com.wq.auth.security.jwt.JwtProvider
 import com.wq.auth.security.jwt.error.JwtException
 import com.wq.auth.security.jwt.error.JwtExceptionCode
 import com.wq.auth.security.principal.PrincipalDetails
+import com.wq.auth.shared.config.CookieFactory
 import io.kotest.core.spec.style.DescribeSpec
-import io.kotest.extensions.spring.SpringTestExtension
+import io.kotest.extensions.spring.SpringExtension
 import org.mockito.BDDMockito.given
 import org.springframework.http.MediaType
+import org.springframework.http.ResponseCookie
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
 import jakarta.servlet.http.Cookie
 import org.hamcrest.Matchers
+import org.hamcrest.Matchers.hasItem
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
+import org.springframework.context.annotation.Import
 import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.MockMvc
 import java.time.Duration
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user
-import com.wq.auth.api.domain.member.entity.Role
 import com.wq.auth.shared.rateLimiter.RateLimiterInterceptor
 import org.mockito.Mockito.*
 import org.mockito.kotlin.whenever
@@ -32,9 +36,10 @@ import org.mockito.kotlin.any
 @WebMvcTest(
     controllers = [AuthController::class],
     properties = ["app.cookie.same-site=Strict"])
+@Import(WebMvcTestSecurityConfig::class)
 class AuthControllerIntegrationTest : DescribeSpec() {
 
-    override fun extensions() = listOf(SpringTestExtension())
+    override val extensions = listOf(SpringExtension())
 
     @Autowired
     lateinit var mockMvc: MockMvc
@@ -44,6 +49,12 @@ class AuthControllerIntegrationTest : DescribeSpec() {
 
     @MockitoBean
     lateinit var authEmailService: AuthEmailService
+
+    @MockitoBean
+    lateinit var memberService: MemberService
+
+    @MockitoBean
+    lateinit var cookieFactory: CookieFactory
 
     @MockitoBean
     lateinit var jwtProperties: JwtProperties
@@ -65,15 +76,31 @@ class AuthControllerIntegrationTest : DescribeSpec() {
             // validateOrThrow는 void이므로 doNothing 사용
             doNothing().whenever(jwtProvider).validateOrThrow(any())
 
-            // getOpaqueId와 getRole Mock 설정
+            // getOpaqueId Mock 설정
             whenever(jwtProvider.getOpaqueId(any())).thenReturn("opaqueId")
-            whenever(jwtProvider.getRole(any())).thenReturn(Role.MEMBER)
+
+            // CookieFactory 기본 스텁 설정 (NPE 방지)
+            whenever(cookieFactory.createAccessTokenCookie(any())).thenAnswer { invocation ->
+                val token = invocation.arguments[0] as String
+                ResponseCookie.from("accessToken", token)
+                    .httpOnly(true).path("/").sameSite("Strict").build()
+            }
+            whenever(cookieFactory.createRefreshTokenCookie(any())).thenAnswer { invocation ->
+                val token = invocation.arguments[0] as String
+                ResponseCookie.from("refreshToken", token)
+                    .httpOnly(true).path("/").sameSite("Strict").build()
+            }
+            whenever(cookieFactory.expireAccessTokenCookie()).thenReturn(
+                ResponseCookie.from("accessToken", "").maxAge(0).path("/").sameSite("Strict").build()
+            )
+            whenever(cookieFactory.expireRefreshTokenCookie()).thenReturn(
+                ResponseCookie.from("refreshToken", "").maxAge(0).path("/").sameSite("Strict").build()
+            )
         }
 
         describe("POST /api/v1/auth/members/refresh") {
             val principal = PrincipalDetails(
-                opaqueId = "opaqueId",
-                role = Role.MEMBER
+                opaqueId = "opaqueId"
             )
 
             context("Web 클라이언트에서 유효한 요청이 주어졌을 때") {
@@ -112,15 +139,25 @@ class AuthControllerIntegrationTest : DescribeSpec() {
                         .andExpect(status().isOk)
                         .andExpect(jsonPath("$.success").value(true))
                         .andExpect(jsonPath("$.message").value("AccessToken 재발급에 성공했습니다."))
-                        // web 응답은 data null, 헤더만 검증
+                        // web 응답: Set-Cookie 헤더가 여러 개(accessToken, refreshToken) 존재하므로 stringValues로 검증
                         .andExpect(
-                            header().string(
+                            header().stringValues(
                                 "Set-Cookie",
-                                Matchers.containsString("refreshToken=$newRefreshToken")
+                                hasItem(Matchers.containsString("refreshToken=$newRefreshToken"))
                             )
                         )
-                        .andExpect(header().string("Set-Cookie", Matchers.containsString("HttpOnly")))
-                        .andExpect(header().string("Set-Cookie", Matchers.containsString("SameSite=Strict")))
+                        .andExpect(
+                            header().stringValues(
+                                "Set-Cookie",
+                                hasItem(Matchers.containsString("HttpOnly"))
+                            )
+                        )
+                        .andExpect(
+                            header().stringValues(
+                                "Set-Cookie",
+                                hasItem(Matchers.containsString("SameSite=Strict"))
+                            )
+                        )
 
                     verify(authService).refreshAccessToken(refreshToken, deviceId)
                 }
@@ -251,11 +288,11 @@ class AuthControllerIntegrationTest : DescribeSpec() {
                         .andExpect(status().isOk)
                         .andExpect(jsonPath("$.success").value(true))
                         .andExpect(jsonPath("$.message").value("로그인에 성공했습니다."))
-                        .andExpect(header().string("Authorization", Matchers.containsString("Bearer ")))
+                        // web 응답: Set-Cookie 헤더가 여러 개이므로 stringValues로 검증
                         .andExpect(
-                            header().string(
+                            header().stringValues(
                                 "Set-Cookie",
-                                Matchers.containsString("refreshToken=$refreshToken")
+                                hasItem(Matchers.containsString("refreshToken=$refreshToken"))
                             )
                         )
 
@@ -312,8 +349,7 @@ class AuthControllerIntegrationTest : DescribeSpec() {
                     val refreshToken = "valid-refresh-token"
                     val clientType = "web"
                     val principal = PrincipalDetails(
-                        opaqueId = "opaqueId",
-                        role = Role.MEMBER
+                        opaqueId = "opaqueId"
                     )
                     val requestBody = """{}"""
 
@@ -330,14 +366,21 @@ class AuthControllerIntegrationTest : DescribeSpec() {
                         .andExpect(status().isOk)
                         .andExpect(jsonPath("$.success").value(true))
                         .andExpect(jsonPath("$.message").value("로그아웃에 성공했습니다."))
-                        .andExpect(jsonPath("$.data").isEmpty)
+                        // data가 null이면 @JsonInclude(NON_NULL)에 의해 JSON에 포함되지 않음
+                        .andExpect(jsonPath("$.data").doesNotExist())
+                        // web 응답: Set-Cookie 헤더가 여러 개이므로 stringValues로 검증
                         .andExpect(
-                            header().string(
+                            header().stringValues(
                                 "Set-Cookie",
-                                Matchers.containsString("refreshToken=")
+                                hasItem(Matchers.containsString("refreshToken="))
                             )
                         )
-                        .andExpect(header().string("Set-Cookie", Matchers.containsString("Max-Age=0")))
+                        .andExpect(
+                            header().stringValues(
+                                "Set-Cookie",
+                                hasItem(Matchers.containsString("Max-Age=0"))
+                            )
+                        )
 
                     verify(authService).logout(refreshToken)
                 }
@@ -349,8 +392,7 @@ class AuthControllerIntegrationTest : DescribeSpec() {
                     val refreshToken = "valid-refresh-token"
                     val clientType = "app"
                     val principal = PrincipalDetails(
-                        opaqueId = "opaqueId",
-                        role = Role.MEMBER
+                        opaqueId = "opaqueId"
                     )
 
                     val requestBody = """{"refreshToken": "$refreshToken"}"""
@@ -367,7 +409,8 @@ class AuthControllerIntegrationTest : DescribeSpec() {
                         .andExpect(status().isOk)
                         .andExpect(jsonPath("$.success").value(true))
                         .andExpect(jsonPath("$.message").value("로그아웃에 성공했습니다."))
-                        .andExpect(jsonPath("$.data").isEmpty)
+                        // data가 null이면 @JsonInclude(NON_NULL)에 의해 JSON에 포함되지 않음
+                        .andExpect(jsonPath("$.data").doesNotExist())
                         .andExpect(header().doesNotExist("Set-Cookie"))
 
                     verify(authService).logout(refreshToken)

--- a/src/test/kotlin/com/wq/auth/integration/JacksonInstantIntegrationTest.kt
+++ b/src/test/kotlin/com/wq/auth/integration/JacksonInstantIntegrationTest.kt
@@ -1,12 +1,12 @@
 package com.wq.auth.integration
 
-import com.fasterxml.jackson.databind.JsonNode
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.wq.auth.api.domain.member.entity.Role
+import tools.jackson.databind.JsonNode
+import tools.jackson.databind.json.JsonMapper
 import com.wq.auth.integration._tnote._TNote
 import com.wq.auth.integration._tnote._TNoteRepository
 import com.wq.auth.security.jwt.JwtProvider
 import com.wq.auth.security.principal.PrincipalDetails
+import com.wq.auth.shared.rateLimiter.RateLimiterInterceptor
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.extensions.spring.SpringExtension
 import io.kotest.matchers.shouldBe
@@ -14,15 +14,14 @@ import io.kotest.matchers.string.shouldContain
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doNothing
 import org.mockito.kotlin.whenever
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
-import com.wq.auth.shared.rateLimiter.RateLimiterInterceptor
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
 import org.springframework.http.MediaType
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user
 import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
-import org.springframework.web.servlet.HandlerInterceptor
 import java.time.Instant
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
@@ -31,80 +30,91 @@ import java.time.ZoneOffset
     properties = [
         "jwt.secret=MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDE=",
         "jwt.access-exp=15m",
-        "jwt.refresh-exp=14d"
+        "jwt.refresh-exp=14d",
+        "INTERNAL_API_SECRET=test-internal-secret",
+        "spring.datasource.url=jdbc:h2:mem:jackson-instant-test;DB_CLOSE_DELAY=-1",
+        "spring.datasource.driver-class-name=org.h2.Driver",
+        "spring.datasource.username=sa",
+        "spring.datasource.password=",
+        "spring.jpa.hibernate.ddl-auto=create-drop",
+        "spring.jpa.database-platform=org.hibernate.dialect.H2Dialect",
+        "spring.mail.host=localhost",
+        "spring.mail.port=25",
+        "spring.mail.username=test",
+        "spring.mail.password=test",
+        "spring.mail.properties.mail.smtp.auth=false",
+        "spring.mail.properties.mail.smtp.starttls.enable=false"
     ]
 )
 @AutoConfigureMockMvc
-class JacksonInstantIntegrationTest(
-    private val repo: _TNoteRepository,
-    private val mockMvc: MockMvc,
-    private val objectMapper: ObjectMapper,
+class JacksonInstantIntegrationTest : StringSpec() {
+
+    override val extensions = listOf(SpringExtension())
+
+    @Autowired
+    lateinit var repo: _TNoteRepository
+
+    @Autowired
+    lateinit var mockMvc: MockMvc
+
+    @Autowired
+    lateinit var objectMapper: JsonMapper
 
     @MockitoBean
-    private val jwtProvider: JwtProvider,
+    lateinit var jwtProvider: JwtProvider
 
     @MockitoBean
-    private val rateLimiterInterceptor: RateLimiterInterceptor
+    lateinit var rateLimiterInterceptor: RateLimiterInterceptor
 
-) : StringSpec({
+    init {
+        beforeTest {
+            whenever(rateLimiterInterceptor.preHandle(any(), any(), any())).thenReturn(true)
+            doNothing().whenever(jwtProvider).validateOrThrow(any())
+            whenever(jwtProvider.getOpaqueId(any())).thenReturn("opaqueId")
+        }
 
-    beforeTest {
-        whenever(rateLimiterInterceptor.preHandle(any(), any(), any())).thenReturn(true)
+        "UTC Instant가 저장/조회 시 동일하다" {
+            // given
+            val utc = Instant.parse("2025-08-12T00:00:00Z")
+            val saved = repo.save(_TNote(title = "hello", publishedAt = utc))
 
-        // JWT 검증을 통과하도록 설정
-        // validateOrThrow는 void이므로 doNothing 사용
-        doNothing().whenever(jwtProvider).validateOrThrow(any())
+            // when
+            val found = repo.findById(saved.id!!).orElseThrow()
 
-        // getOpaqueId와 getRole Mock 설정
-        whenever(jwtProvider.getOpaqueId(any())).thenReturn("opaqueId")
-        whenever(jwtProvider.getRole(any())).thenReturn(Role.MEMBER)
+            // then
+            found.publishedAt shouldBe utc
+        }
+
+        "응답 JSON은 +09:00 및 :ss로 나가고 시점은 동일하다" {
+            // given
+            val utc = Instant.parse("2025-08-12T00:00:00Z")
+            val saved = repo.save(_TNote(title = "hello", publishedAt = utc))
+            val accessToken = "valid-access-token"
+
+            val principal = PrincipalDetails(
+                opaqueId = "opaqueId"
+            )
+
+            // when
+            val res = mockMvc.get("/test-notes/{id}", saved.id!!) {
+                accept = MediaType.APPLICATION_JSON
+                header("Authorization", "Bearer $accessToken")
+                with(user(principal))
+            }.andReturn().response
+            res.status shouldBe 200
+
+            // then: 포맷 문자열 검증 (+09:00 & :ss)
+            val body = res.contentAsString
+            body shouldContain "\"publishedAt\":\"2025-08-12T09:00:00+09:00\""
+
+            // 의미 검증: 파싱하여 오프셋/Instant 동일성 확인
+            val node: JsonNode = objectMapper.readTree(body)
+            val iso = node["publishedAt"]?.asText()
+                ?: error("publishedAt 필드가 없음.")
+            val parsed = OffsetDateTime.parse(iso)
+
+            parsed.offset shouldBe ZoneOffset.ofHours(9)  // 응답은 +09:00
+            parsed.toInstant() shouldBe utc               // 시점은 동일(UTC)
+        }
     }
-
-    "UTC Instant가 저장/조회 시 동일하다" {
-        // given
-        val utc = Instant.parse("2025-08-12T00:00:00Z")
-        val saved = repo.save(_TNote(title = "hello", publishedAt = utc))
-
-        // when
-        val found = repo.findById(saved.id!!).orElseThrow()
-
-        // then
-        found.publishedAt shouldBe utc
-    }
-
-    "응답 JSON은 +09:00 및 :ss로 나가고 시점은 동일하다" {
-        // given
-        val utc = Instant.parse("2025-08-12T00:00:00Z")
-        val saved = repo.save(_TNote(title = "hello", publishedAt = utc))
-        val accessToken = "valid-access-token"
-
-        val principal = PrincipalDetails(
-            opaqueId = "opaqueId",
-            role = Role.MEMBER
-        )
-
-
-        // when
-        val res = mockMvc.get("/test-notes/{id}", saved.id!!) {
-            accept = MediaType.APPLICATION_JSON
-            header("Authorization", "Bearer $accessToken")
-            with(user(principal))
-        }.andReturn().response
-        res.status shouldBe 200
-
-        // then: 포맷 문자열 검증 (+09:00 & :ss)
-        val body = res.contentAsString
-        body shouldContain "\"publishedAt\":\"2025-08-12T09:00:00+09:00\""
-
-        // 의미 검증: 파싱하여 오프셋/Instant 동일성 확인
-        val node: JsonNode = objectMapper.readTree(body)
-        val iso = node["publishedAt"]?.asText()
-            ?: error("publishedAt 필드가 없음.")
-        val parsed = OffsetDateTime.parse(iso)
-
-        parsed.offset shouldBe ZoneOffset.ofHours(9)  // 응답은 +09:00
-        parsed.toInstant() shouldBe utc               // 시점은 동일(UTC)
-    }
-}) {
-    override fun extensions() = listOf(SpringExtension)
 }

--- a/src/test/kotlin/com/wq/auth/integration/MemberWithdrawControllerTest.kt
+++ b/src/test/kotlin/com/wq/auth/integration/MemberWithdrawControllerTest.kt
@@ -1,0 +1,119 @@
+package com.wq.auth.integration
+
+import com.wq.auth.api.controller.member.MemberController
+import com.wq.auth.api.domain.member.MemberService
+import com.wq.auth.security.jwt.JwtProvider
+import com.wq.auth.security.principal.PrincipalDetails
+import com.wq.auth.shared.config.CookieFactory
+import com.wq.auth.shared.rateLimiter.RateLimiterInterceptor
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.extensions.spring.SpringExtension
+import org.hamcrest.Matchers
+import org.mockito.kotlin.*
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
+import org.springframework.context.annotation.Import
+import org.springframework.http.ResponseCookie
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
+
+@WebMvcTest(
+    controllers = [MemberController::class],
+    properties = ["app.cookie.same-site=Strict"]
+)
+@Import(WebMvcTestSecurityConfig::class)
+class MemberWithdrawControllerTest : DescribeSpec() {
+
+    @Autowired
+    lateinit var mockMvc: MockMvc
+
+    @MockitoBean
+    lateinit var memberService: MemberService
+
+    @MockitoBean
+    lateinit var cookieFactory: CookieFactory
+
+    @MockitoBean
+    lateinit var jwtProvider: JwtProvider
+
+    @MockitoBean
+    lateinit var rateLimiterInterceptor: RateLimiterInterceptor
+
+    override val extensions = listOf(SpringExtension())
+
+    init {
+        beforeTest {
+            reset(memberService, cookieFactory)
+            whenever(rateLimiterInterceptor.preHandle(any(), any(), any())).thenReturn(true)
+            doNothing().whenever(jwtProvider).validateOrThrow(any())
+            whenever(jwtProvider.getOpaqueId(any())).thenReturn("test-opaque-id")
+        }
+
+        describe("DELETE /api/v1/auth/members/me") {
+
+            context("인증된 web 클라이언트 요청") {
+                it("탈퇴 성공 후 쿠키 만료 Set-Cookie 헤더를 반환한다") {
+                    val principal = PrincipalDetails(opaqueId = "test-opaque-id")
+
+                    whenever(cookieFactory.expireAccessTokenCookie()).thenReturn(
+                        ResponseCookie.from("accessToken", "").maxAge(0).build()
+                    )
+                    whenever(cookieFactory.expireRefreshTokenCookie()).thenReturn(
+                        ResponseCookie.from("refreshToken", "").maxAge(0).build()
+                    )
+
+                    mockMvc.perform(
+                        delete("/api/v1/auth/members/me")
+                            .header("X-Client-Type", "web")
+                            .with(csrf())
+                            .with(user(principal))
+                    )
+                        .andExpect(status().isOk)
+                        .andExpect(jsonPath("$.success").value(true))
+                        .andExpect(jsonPath("$.message").value("회원 탈퇴 성공"))
+                        .andExpect(header().string("Set-Cookie", Matchers.containsString("Max-Age=0")))
+
+                    verify(memberService).withdraw("test-opaque-id", "web")
+                    verify(cookieFactory).expireAccessTokenCookie()
+                    verify(cookieFactory).expireRefreshTokenCookie()
+                }
+            }
+
+            context("인증된 app 클라이언트 요청") {
+                it("탈퇴 성공하고 Set-Cookie 헤더가 없다") {
+                    val principal = PrincipalDetails(opaqueId = "test-opaque-id")
+
+                    mockMvc.perform(
+                        delete("/api/v1/auth/members/me")
+                            .header("X-Client-Type", "app")
+                            .with(csrf())
+                            .with(user(principal))
+                    )
+                        .andExpect(status().isOk)
+                        .andExpect(jsonPath("$.success").value(true))
+                        .andExpect(jsonPath("$.message").value("회원 탈퇴 성공"))
+                        .andExpect(header().doesNotExist("Set-Cookie"))
+
+                    verify(memberService).withdraw("test-opaque-id", "app")
+                    verify(cookieFactory, never()).expireAccessTokenCookie()
+                    verify(cookieFactory, never()).expireRefreshTokenCookie()
+                }
+            }
+
+            context("미인증 요청") {
+                it("401 Unauthorized를 반환한다") {
+                    mockMvc.perform(
+                        delete("/api/v1/auth/members/me")
+                            .header("X-Client-Type", "web")
+                            .with(csrf())
+                    )
+                        .andExpect(status().isUnauthorized)
+                }
+            }
+        }
+    }
+}

--- a/src/test/kotlin/com/wq/auth/integration/SocialLinkControllerTest.kt
+++ b/src/test/kotlin/com/wq/auth/integration/SocialLinkControllerTest.kt
@@ -1,22 +1,23 @@
 package com.wq.auth.integration
 
-import com.fasterxml.jackson.databind.ObjectMapper
+import tools.jackson.databind.json.JsonMapper
 import com.wq.auth.api.controller.auth.SocialLoginController
 import com.wq.auth.api.domain.auth.SocialLinkService
 import com.wq.auth.api.domain.auth.SocialLoginService
-import com.wq.auth.api.domain.member.entity.Role
 import com.wq.auth.api.domain.oauth.error.SocialLoginException
 import com.wq.auth.api.domain.oauth.error.SocialLoginExceptionCode
 import com.wq.auth.security.jwt.JwtProvider
 import com.wq.auth.security.principal.PrincipalDetails
+import com.wq.auth.shared.config.CookieFactory
 import com.wq.auth.shared.rateLimiter.RateLimiterInterceptor
 import io.kotest.core.spec.style.DescribeSpec
-import io.kotest.extensions.spring.SpringTestExtension
+import io.kotest.extensions.spring.SpringExtension
 import jakarta.servlet.http.Cookie
 import org.mockito.BDDMockito.given
 import org.mockito.kotlin.*
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
+import org.springframework.context.annotation.Import
 import org.springframework.http.MediaType
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user
@@ -30,21 +31,25 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
  * 소셜 계정 연동 Controller 단위 테스트 (Kotest + Mockito)
  */
 @WebMvcTest(controllers = [SocialLoginController::class])
+@Import(WebMvcTestSecurityConfig::class)
 class SocialLinkControllerTest : DescribeSpec() {
 
-    override fun extensions() = listOf(SpringTestExtension())
+    override val extensions = listOf(SpringExtension())
 
     @Autowired
     lateinit var mockMvc: MockMvc
 
     @Autowired
-    lateinit var objectMapper: ObjectMapper
+    lateinit var objectMapper: JsonMapper
 
     @MockitoBean
     lateinit var socialLoginService: SocialLoginService
 
     @MockitoBean
     lateinit var socialLinkService: SocialLinkService
+
+    @MockitoBean
+    lateinit var cookieFactory: CookieFactory
 
     @MockitoBean
     lateinit var jwtProvider: JwtProvider
@@ -63,9 +68,8 @@ class SocialLinkControllerTest : DescribeSpec() {
             // validateOrThrow는 void이므로 doNothing 사용
             doNothing().whenever(jwtProvider).validateOrThrow(any())
 
-            // getOpaqueId와 getRole Mock 설정
+            // getOpaqueId Mock 설정
             whenever(jwtProvider.getOpaqueId(any())).thenReturn("opaqueId")
-            whenever(jwtProvider.getRole(any())).thenReturn(Role.MEMBER)
         }
 
         describe("POST /api/v1/auth/link/{provider}") {
@@ -76,8 +80,7 @@ class SocialLinkControllerTest : DescribeSpec() {
             val accessToken = "valid-access-token"
 
             val principal = PrincipalDetails(
-                opaqueId = "opaqueId",
-                role = Role.MEMBER
+                opaqueId = "opaqueId"
             )
 
             context("Google 계정 연동 - 신규 연동 성공") {

--- a/src/test/kotlin/com/wq/auth/integration/WebMvcTestSecurityConfig.kt
+++ b/src/test/kotlin/com/wq/auth/integration/WebMvcTestSecurityConfig.kt
@@ -1,0 +1,122 @@
+package com.wq.auth.integration
+
+import com.wq.auth.security.jwt.error.JwtExceptionCode
+import com.wq.auth.security.principal.PrincipalDetails
+import com.wq.auth.web.common.response.CommonResponse
+import jakarta.servlet.http.HttpServletRequest
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+import org.springframework.core.MethodParameter
+import org.springframework.core.Ordered
+import org.springframework.core.annotation.Order
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.authentication.InsufficientAuthenticationException
+import org.springframework.security.core.Authentication
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.security.core.context.SecurityContext
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.web.bind.support.WebDataBinderFactory
+import org.springframework.web.context.request.NativeWebRequest
+import org.springframework.web.method.support.HandlerMethodArgumentResolver
+import org.springframework.web.method.support.ModelAndViewContainer
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+/**
+ * @WebMvcTest 슬라이스에서 @AuthenticationPrincipal PrincipalDetails 파라미터 해석을 위한
+ * 테스트 전용 설정.
+ *
+ * Spring Boot 4 / Spring Security 7 환경에서 @WebMvcTest 컨텍스트에는
+ * FilterChainProxy가 MockMvc 필터 체인에 포함되지 않아 SecurityContextHolderFilter가
+ * 동작하지 않습니다. 그 결과 SecurityContextHolder가 비어 있어
+ * AuthenticationPrincipalArgumentResolver가 null을 반환합니다.
+ *
+ * 해결책: SecurityMockMvcRequestPostProcessors.user()는 인증 정보를
+ * HttpSession의 "SPRING_SECURITY_CONTEXT" 속성에 저장합니다(HttpSessionSecurityContextRepository 폴백).
+ * 이를 직접 읽어 PrincipalDetails를 추출합니다.
+ *
+ * 미인증 요청(인증 정보 없음) → InsufficientAuthenticationException 발생 →
+ * WebMvcTestAuthExceptionHandler가 401을 반환합니다.
+ */
+@TestConfiguration
+class WebMvcTestSecurityConfig : WebMvcConfigurer {
+    override fun addArgumentResolvers(resolvers: MutableList<HandlerMethodArgumentResolver>) {
+        resolvers.add(0, PrincipalDetailsArgumentResolver())
+    }
+
+    @Bean
+    fun webMvcTestAuthExceptionHandler(): WebMvcTestAuthExceptionHandler =
+        WebMvcTestAuthExceptionHandler()
+}
+
+/**
+ * @AuthenticationPrincipal 어노테이션이 달린 PrincipalDetails 파라미터를 해석합니다.
+ *
+ * 인증 정보 탐색 순서:
+ * 1. SecurityContextHolder (필터 체인이 동작하는 경우)
+ * 2. HttpSession의 SPRING_SECURITY_CONTEXT 속성
+ *    (SecurityMockMvcRequestPostProcessors.user() 폴백 경로)
+ *
+ * 인증 정보가 없으면 InsufficientAuthenticationException을 발생시켜
+ * 컨트롤러 메서드 실행 전에 401 응답이 반환되도록 합니다.
+ */
+class PrincipalDetailsArgumentResolver : HandlerMethodArgumentResolver {
+    companion object {
+        private const val SPRING_SECURITY_CONTEXT_KEY = "SPRING_SECURITY_CONTEXT"
+    }
+
+    override fun supportsParameter(parameter: MethodParameter): Boolean {
+        return parameter.hasParameterAnnotation(AuthenticationPrincipal::class.java) &&
+            PrincipalDetails::class.java.isAssignableFrom(parameter.parameterType)
+    }
+
+    override fun resolveArgument(
+        parameter: MethodParameter,
+        mavContainer: ModelAndViewContainer?,
+        webRequest: NativeWebRequest,
+        binderFactory: WebDataBinderFactory?
+    ): Any? {
+        val authentication = findAuthentication(webRequest)
+            ?: throw InsufficientAuthenticationException("인증 정보가 없습니다.")
+        val principal = authentication.principal
+        return if (principal is PrincipalDetails) principal
+        else throw InsufficientAuthenticationException("유효한 PrincipalDetails가 없습니다.")
+    }
+
+    private fun findAuthentication(webRequest: NativeWebRequest): Authentication? {
+        // 1. SecurityContextHolder 확인 (필터 체인이 완전히 동작할 때)
+        val holderAuth = SecurityContextHolder.getContext().authentication
+        if (holderAuth != null) return holderAuth
+
+        // 2. HttpSession 확인 (SecurityMockMvcRequestPostProcessors.user() 폴백)
+        val request = webRequest.getNativeRequest(HttpServletRequest::class.java) ?: return null
+        val session = request.getSession(false) ?: return null
+        val context = session.getAttribute(SPRING_SECURITY_CONTEXT_KEY) as? SecurityContext ?: return null
+        return context.authentication
+    }
+}
+
+/**
+ * 테스트 전용: InsufficientAuthenticationException → 401 Unauthorized 변환기.
+ *
+ * 프로덕션 환경에서는 FilterChainProxy → ExceptionTranslationFilter →
+ * JwtAuthenticationEntryPoint 경로로 401이 처리됩니다.
+ * @WebMvcTest 슬라이스에서는 필터 체인이 없으므로, 이 어드바이스가 대신 처리합니다.
+ *
+ * @Order(HIGHEST_PRECEDENCE)로 GlobalExceptionHandler보다 먼저 탐색되어
+ * InsufficientAuthenticationException을 가로채 401을 반환합니다.
+ */
+@RestControllerAdvice
+@Order(Ordered.HIGHEST_PRECEDENCE)
+class WebMvcTestAuthExceptionHandler {
+
+    @ExceptionHandler(InsufficientAuthenticationException::class)
+    fun handleInsufficientAuthentication(
+        e: InsufficientAuthenticationException
+    ): ResponseEntity<CommonResponse<Unit>> {
+        val body = CommonResponse.fail(JwtExceptionCode.TOKEN_MISSING)
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(body)
+    }
+}

--- a/src/test/kotlin/com/wq/auth/integration/security/SecurityAuthorizationIntegrationTest.kt
+++ b/src/test/kotlin/com/wq/auth/integration/security/SecurityAuthorizationIntegrationTest.kt
@@ -1,172 +1,143 @@
 package com.wq.auth.integration.security
 
-import com.wq.auth.api.domain.member.entity.Role
 import com.wq.auth.security.jwt.JwtProvider
 import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.extensions.spring.SpringExtension
 import io.kotest.matchers.shouldBe
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
 import org.springframework.http.MediaType
-import org.springframework.test.context.TestConstructor
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 
 /**
  * JWT 기반 Spring Security 통합 테스트
- * 
+ *
  * 테스트 시나리오:
  * 1. 공개 API - 토큰 없이 접근 가능
  * 2. 인증 API - 유효한 토큰 필요
- * 3. 관리자 API - ADMIN 역할 필요
- * 4. JWT 토큰 형식 검증 (Bearer, 만료, 잘못된 형식)
- * 5. 권한별 접근 제어 (401/403 응답)
+ * 3. JWT 토큰 형식 검증 (Bearer, 만료, 잘못된 형식)
+ * 4. 권한별 접근 제어 (401 응답)
+ *
+ * 참고: Role/Admin 기능은 현재 API에서 제거되어 관련 케이스는 제외됨
  */
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    properties = [
+        "INTERNAL_API_SECRET=test-internal-secret",
+        "spring.datasource.url=jdbc:h2:mem:security-test;DB_CLOSE_DELAY=-1",
+        "spring.datasource.driver-class-name=org.h2.Driver",
+        "spring.datasource.username=sa",
+        "spring.datasource.password=",
+        "spring.jpa.hibernate.ddl-auto=create-drop",
+        "spring.jpa.database-platform=org.hibernate.dialect.H2Dialect",
+        "jwt.secret=MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDE=",
+        "jwt.access-exp=15m",
+        "jwt.refresh-exp=14d",
+        "spring.mail.host=localhost",
+        "spring.mail.port=25",
+        "spring.mail.username=test",
+        "spring.mail.password=test",
+        "spring.mail.properties.mail.smtp.auth=false",
+        "spring.mail.properties.mail.smtp.starttls.enable=false"
+    ]
+)
 @AutoConfigureMockMvc
-@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
-class JwtSpringSecurityIntegrationTest(
-    private val mockMvc: MockMvc,
-    private val jwtProvider: JwtProvider
-) : BehaviorSpec({
+class JwtSpringSecurityIntegrationTest : BehaviorSpec() {
 
-    given("JWT 기반 Spring Security 시스템에서") {
+    override val extensions = listOf(SpringExtension())
 
-        `when`("공개 API에 토큰 없이 접근하면") {
-            then("200 OK 응답을 받아야 한다") {
-                val result = mockMvc.perform(
-                    get("/api/public/test")
-                        .contentType(MediaType.APPLICATION_JSON)
-                ).andReturn()
+    @Autowired
+    lateinit var mockMvc: MockMvc
 
-                result.response.status shouldBe 200
+    @Autowired
+    lateinit var jwtProvider: JwtProvider
+
+    init {
+        given("JWT 기반 Spring Security 시스템에서") {
+
+            `when`("공개 API에 토큰 없이 접근하면") {
+                then("200 OK 응답을 받아야 한다") {
+                    val result = mockMvc.perform(
+                        get("/api/public/test")
+                            .contentType(MediaType.APPLICATION_JSON)
+                    ).andReturn()
+
+                    result.response.status shouldBe 200
+                }
             }
-        }
 
-        `when`("인증된 사용자 API에 유효한 MEMBER 토큰으로 접근하면") {
-            then("200 OK 응답을 받아야 한다") {
-                // Given: MEMBER 역할 토큰 생성
-                val memberToken = jwtProvider.createAccessToken(
-                    opaqueId = "550e8400-e29b-41d4-a716-446655440000",
-                    role = Role.MEMBER
-                )
+            `when`("인증된 사용자 API에 유효한 토큰으로 접근하면") {
+                then("200 OK 응답을 받아야 한다") {
+                    // Given: 토큰 생성
+                    val memberToken = jwtProvider.createAccessToken(
+                        opaqueId = "550e8400-e29b-41d4-a716-446655440000"
+                    )
 
-                val result = mockMvc.perform(
-                    get("/api/test")
-                        .header("Authorization", "Bearer $memberToken")
-                        .contentType(MediaType.APPLICATION_JSON)
-                ).andReturn()
+                    val result = mockMvc.perform(
+                        get("/api/test")
+                            .header("Authorization", "Bearer $memberToken")
+                            .contentType(MediaType.APPLICATION_JSON)
+                    ).andReturn()
 
-                result.response.status shouldBe 200
+                    result.response.status shouldBe 200
+                }
             }
-        }
 
-        `when`("인증된 사용자 API에 유효한 ADMIN 토큰으로 접근하면") {
-            then("200 OK 응답을 받아야 한다") {
-                // Given: ADMIN 역할 토큰 생성
-                val adminToken = jwtProvider.createAccessToken(
-                    opaqueId = "660e8400-e29b-41d4-a716-446655440001",
-                    role = Role.ADMIN
-                )
+            `when`("인증된 사용자 API에 토큰 없이 접근하면") {
+                then("401 Unauthorized 응답을 받아야 한다") {
+                    val result = mockMvc.perform(
+                        get("/api/authenticated/test")
+                            .contentType(MediaType.APPLICATION_JSON)
+                    ).andReturn()
 
-                val result = mockMvc.perform(
-                    get("/api/test")
-                        .header("Authorization", "Bearer $adminToken")
-                        .contentType(MediaType.APPLICATION_JSON)
-                ).andReturn()
-
-                result.response.status shouldBe 200
+                    result.response.status shouldBe 401
+                }
             }
-        }
 
-        `when`("관리자 API에 ADMIN 토큰으로 접근하면") {
-            then("200 OK 응답을 받아야 한다") {
-                // Given: ADMIN 역할 토큰 생성
-                val adminToken = jwtProvider.createAccessToken(
-                    opaqueId = "660e8400-e29b-41d4-a716-446655440001",
-                    role = Role.ADMIN
-                )
+            `when`("잘못된 JWT 토큰으로 접근하면") {
+                then("401 Unauthorized 응답을 받아야 한다") {
+                    val result = mockMvc.perform(
+                        get("/api/authenticated/test")
+                            .header("Authorization", "Bearer invalid.token.here")
+                            .contentType(MediaType.APPLICATION_JSON)
+                    ).andReturn()
 
-                val result = mockMvc.perform(
-                    get("/api/admin/test")
-                        .header("Authorization", "Bearer $adminToken")
-                        .contentType(MediaType.APPLICATION_JSON)
-                ).andReturn()
-
-                result.response.status shouldBe 200
+                    result.response.status shouldBe 401
+                }
             }
-        }
 
-        `when`("관리자 API에 MEMBER 토큰으로 접근하면") {
-            then("403 Forbidden 응답을 받아야 한다") {
-                // Given: MEMBER 역할 토큰 생성
-                val memberToken = jwtProvider.createAccessToken(
-                    opaqueId = "550e8400-e29b-41d4-a716-446655440000",
-                    role = Role.MEMBER
-                )
+            `when`("Bearer 없는 토큰으로 접근하면") {
+                then("401 Unauthorized 응답을 받아야 한다") {
+                    val memberToken = jwtProvider.createAccessToken(
+                        opaqueId = "550e8400-e29b-41d4-a716-446655440000"
+                    )
 
-                val result = mockMvc.perform(
-                    get("/api/admin/test")
-                        .header("Authorization", "Bearer $memberToken")
-                        .contentType(MediaType.APPLICATION_JSON)
-                ).andReturn()
+                    val result = mockMvc.perform(
+                        get("/api/authenticated/test")
+                            .header("Authorization", memberToken) // Bearer 없이
+                            .contentType(MediaType.APPLICATION_JSON)
+                    ).andReturn()
 
-                result.response.status shouldBe 403
+                    result.response.status shouldBe 401
+                }
             }
-        }
 
-        `when`("인증된 사용자 API에 토큰 없이 접근하면") {
-            then("401 Unauthorized 응답을 받아야 한다") {
-                val result = mockMvc.perform(
-                    get("/api/authenticated/test")
-                        .contentType(MediaType.APPLICATION_JSON)
-                ).andReturn()
+            `when`("만료된 JWT 토큰으로 접근하면") {
+                then("401 Unauthorized 응답을 받아야 한다") {
+                    // Given: 만료된 토큰 (과거 시간으로 설정)
+                    val expiredToken = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0LXVzZXIiLCJpYXQiOjE2MDAwMDAwMDAsImV4cCI6MTYwMDAwMDAwMX0.invalid"
 
-                result.response.status shouldBe 401
-            }
-        }
+                    val result = mockMvc.perform(
+                        get("/api/authenticated/test")
+                            .header("Authorization", "Bearer $expiredToken")
+                            .contentType(MediaType.APPLICATION_JSON)
+                    ).andReturn()
 
-        `when`("잘못된 JWT 토큰으로 접근하면") {
-            then("401 Unauthorized 응답을 받아야 한다") {
-                val result = mockMvc.perform(
-                    get("/api/authenticated/test")
-                        .header("Authorization", "Bearer invalid.token.here")
-                        .contentType(MediaType.APPLICATION_JSON)
-                ).andReturn()
-
-                result.response.status shouldBe 401
-            }
-        }
-
-        `when`("Bearer 없는 토큰으로 접근하면") {
-            then("401 Unauthorized 응답을 받아야 한다") {
-                val memberToken = jwtProvider.createAccessToken(
-                    opaqueId = "550e8400-e29b-41d4-a716-446655440000",
-                    role = Role.MEMBER
-                )
-
-                val result = mockMvc.perform(
-                    get("/api/authenticated/test")
-                        .header("Authorization", memberToken) // Bearer 없이
-                        .contentType(MediaType.APPLICATION_JSON)
-                ).andReturn()
-
-                result.response.status shouldBe 401
-            }
-        }
-
-        `when`("만료된 JWT 토큰으로 접근하면") {
-            then("401 Unauthorized 응답을 받아야 한다") {
-                // Given: 만료된 토큰 (과거 시간으로 설정)
-                val expiredToken = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0LXVzZXIiLCJpYXQiOjE2MDAwMDAwMDAsImV4cCI6MTYwMDAwMDAwMX0.invalid"
-
-                val result = mockMvc.perform(
-                    get("/api/authenticated/test")
-                        .header("Authorization", "Bearer $expiredToken")
-                        .contentType(MediaType.APPLICATION_JSON)
-                ).andReturn()
-
-                result.response.status shouldBe 401
+                    result.response.status shouldBe 401
+                }
             }
         }
     }
-})
+}

--- a/src/test/kotlin/com/wq/auth/unit/JacksonInstantModuleTest.kt
+++ b/src/test/kotlin/com/wq/auth/unit/JacksonInstantModuleTest.kt
@@ -1,21 +1,25 @@
 package com.wq.auth.unit
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.databind.SerializationFeature
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.wq.auth.shared.time.ZoneProvider
 import io.kotest.core.spec.style.StringSpec
 import java.time.Instant
 import java.time.ZoneId
-import com.fasterxml.jackson.databind.module.SimpleModule
+import tools.jackson.databind.module.SimpleModule
+import tools.jackson.databind.json.JsonMapper
 import com.wq.auth.shared.time.InstantFromIsoDeserializer
 import com.wq.auth.shared.time.InstantToZoneSerializer
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 
+/**
+ * InstantToZoneSerializer / InstantFromIsoDeserializer 단위 테스트.
+ *
+ * Spring Boot 4는 Jackson 3.x(tools.jackson.*)를 사용하므로 JsonMapper와
+ * tools.jackson.databind.module.SimpleModule을 직접 사용합니다.
+ */
 class JacksonInstantModuleTest : StringSpec({
 
-    fun mapperWith(zoneId: String): ObjectMapper {
+    fun mapperWith(zoneId: String): JsonMapper {
         val zoneProvider = object : ZoneProvider {
             override fun zoneId(): ZoneId = ZoneId.of(zoneId)
         }
@@ -23,10 +27,9 @@ class JacksonInstantModuleTest : StringSpec({
             addSerializer(Instant::class.java, InstantToZoneSerializer(zoneProvider))
             addDeserializer(Instant::class.java, InstantFromIsoDeserializer())
         }
-        return ObjectMapper()
-            .registerModule(JavaTimeModule())
-            .registerModule(module)
-            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+        return JsonMapper.builder()
+            .addModule(module)
+            .build()
     }
 
     "Instant → JSON 직렬화 시 Asia/Seoul(+09:00)로 변환된다" {

--- a/src/test/kotlin/com/wq/auth/unit/MemberServiceTest.kt
+++ b/src/test/kotlin/com/wq/auth/unit/MemberServiceTest.kt
@@ -23,7 +23,7 @@ class MemberServiceTest : DescribeSpec({
     beforeEach {
         memberRepository = mock<MemberRepository>()
         authProviderRepository = mock<AuthProviderRepository>()
-        memberService = MemberService(memberRepository, authProviderRepository)
+        memberService = MemberService(memberRepository, authProviderRepository, mock(), mock())
     }
 
     describe("사용자 정보 조회 테스트") {

--- a/src/test/kotlin/com/wq/auth/unit/MemberWithdrawServiceTest.kt
+++ b/src/test/kotlin/com/wq/auth/unit/MemberWithdrawServiceTest.kt
@@ -1,0 +1,98 @@
+package com.wq.auth.unit
+
+import com.wq.auth.api.domain.auth.AuthProviderRepository
+import com.wq.auth.api.domain.auth.RefreshTokenRepository
+import com.wq.auth.api.domain.member.MemberRepository
+import com.wq.auth.api.domain.member.MemberService
+import com.wq.auth.api.domain.member.MemberWithdrawalAuditRepository
+import com.wq.auth.api.domain.member.entity.MemberEntity
+import com.wq.auth.api.domain.member.entity.MemberWithdrawalAuditEntity
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import org.mockito.ArgumentCaptor
+import org.mockito.kotlin.*
+import java.util.Optional
+
+class MemberWithdrawServiceTest : DescribeSpec({
+
+    lateinit var memberRepository: MemberRepository
+    lateinit var authProviderRepository: AuthProviderRepository
+    lateinit var refreshTokenRepository: RefreshTokenRepository
+    lateinit var memberWithdrawalAuditRepository: MemberWithdrawalAuditRepository
+    lateinit var memberService: MemberService
+
+    beforeEach {
+        memberRepository = mock()
+        authProviderRepository = mock()
+        refreshTokenRepository = mock()
+        memberWithdrawalAuditRepository = mock()
+        memberService = MemberService(
+            memberRepository,
+            authProviderRepository,
+            refreshTokenRepository,
+            memberWithdrawalAuditRepository,
+        )
+    }
+
+    describe("withdraw - 회원 탈퇴") {
+
+        it("정상적인 opaqueId가 주어지면 자식 먼저 부모 나중 순서로 삭제한다") {
+            // given
+            val opaqueId = "test-opaque-id"
+            val mockMember = mock<MemberEntity>()
+            whenever(mockMember.opaqueId).thenReturn(opaqueId)
+            whenever(memberRepository.findByOpaqueId(opaqueId)).thenReturn(Optional.of(mockMember))
+
+            val auditCaptor = ArgumentCaptor.forClass(MemberWithdrawalAuditEntity::class.java)
+            whenever(memberWithdrawalAuditRepository.save(any<MemberWithdrawalAuditEntity>())).thenAnswer { it.arguments[0] }
+
+            // when
+            memberService.withdraw(opaqueId, "app")
+
+            // then
+            verify(memberWithdrawalAuditRepository).save(auditCaptor.capture())
+            val audit = auditCaptor.value
+            audit.opaqueId shouldBe opaqueId
+            audit.sourceClient shouldBe "app"
+
+            val inOrder = inOrder(memberWithdrawalAuditRepository, refreshTokenRepository, authProviderRepository, memberRepository)
+            inOrder.verify(memberWithdrawalAuditRepository).save(any<MemberWithdrawalAuditEntity>())
+            inOrder.verify(refreshTokenRepository).deleteByMember(mockMember)
+            inOrder.verify(authProviderRepository).deleteByMember(mockMember)
+            inOrder.verify(memberRepository).delete(mockMember)
+        }
+
+        it("존재하지 않는 opaqueId가 주어지면 예외 없이 멱등 성공한다") {
+            // given
+            val opaqueId = "already-withdrawn-id"
+            whenever(memberRepository.findByOpaqueId(opaqueId)).thenReturn(Optional.empty())
+
+            // when - 예외가 발생하지 않아야 함
+            memberService.withdraw(opaqueId, "app")
+
+            // then
+            verify(memberRepository).findByOpaqueId(opaqueId)
+            verify(memberWithdrawalAuditRepository, never()).save(any<MemberWithdrawalAuditEntity>())
+            verify(refreshTokenRepository, never()).deleteByMember(any())
+            verify(authProviderRepository, never()).deleteByMember(any())
+            verify(memberRepository, never()).delete(any<MemberEntity>())
+        }
+
+        it("sourceClient가 null이어도 정상 처리된다") {
+            // given
+            val opaqueId = "test-opaque-id"
+            val mockMember = mock<MemberEntity>()
+            whenever(mockMember.opaqueId).thenReturn(opaqueId)
+            whenever(memberRepository.findByOpaqueId(opaqueId)).thenReturn(Optional.of(mockMember))
+            whenever(memberWithdrawalAuditRepository.save(any<MemberWithdrawalAuditEntity>())).thenAnswer { it.arguments[0] }
+
+            // when
+            memberService.withdraw(opaqueId, null)
+
+            // then
+            val captor = ArgumentCaptor.forClass(MemberWithdrawalAuditEntity::class.java)
+            verify(memberWithdrawalAuditRepository).save(captor.capture())
+            captor.value.sourceClient shouldBe null
+        }
+    }
+})

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="WARN">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+    <logger name="com.wq.auth" level="DEBUG"/>
+    <logger name="org.springframework.web.servlet" level="DEBUG"/>
+    <logger name="org.springframework.security" level="DEBUG"/>
+    <logger name="org.springframework.web.method.support.HandlerMethodArgumentResolverComposite" level="TRACE"/>
+</configuration>


### PR DESCRIPTION
## 개요
회원탈퇴(계정 즉시 삭제) API를 구현합니다. 유예 기간 없이 인증된 본인의 계정을 즉시 하드 삭제하며, 소비 서비스(모바일청첩장 등)가 자기 데이터 삭제 후 호출하는 것을 전제로 합니다.

커밋은 논리 단위로 2개입니다:
1. `test:` Spring Boot 4·kotest 6 테스트 인프라 마이그레이션 (선행 필수)
2. `feat:` 회원탈퇴 기능

## 회원탈퇴 기능
- **`DELETE /api/v1/auth/members/me`** (`@AuthenticatedApi`): 쿠키 accessToken으로 본인 식별 → 즉시 삭제
- `MemberService.withdraw`: 감사기록 저장 → `refresh_token` → `auth_provider` → `member` 순 하드 삭제(FK 안전), 이미 탈퇴 시 멱등 성공
- 전 기기 refreshToken 무효화, web 클라이언트는 쿠키 만료(app은 바디 토큰 폐기)
- `MemberWithdrawalAuditEntity`: `opaque_id·withdrawn_at·source_client`만 저장(PII·사유 미포함 — 사유는 소비 서비스가 보관)
- 기존 무인증 `DELETE /api/v1/members/{id}` 및 `MemberService.delete` **제거**

## 테스트 인프라 마이그레이션 (선행 커밋)
기존 dev는 SB4/kotest6 마이그레이션이 미완이라 테스트가 **컴파일조차 안 되는 상태**였습니다. 이를 완성했습니다:
- `kotest-extensions-spring`을 kotest 6 좌표(`io.kotest:kotest-extensions-spring`)로 교체 + `SpringExtension()` 인스턴스화
- `spring-boot-webmvc-test` 의존성 추가(SB4에서 `@WebMvcTest`/`@AutoConfigureMockMvc` 분리)
- `JacksonTimeConfig`를 Jackson 3.x(`tools.jackson.*`)로 포팅(SB4 Instant 직렬화 복구)
- `@WebMvcTest` 슬라이스 인증 헬퍼(`WebMvcTestSecurityConfig`) 추가 + 컨트롤러 의존성 목 정합성
- 제거된 Role enum 참조 정리, `springdoc.swagger-ui.path` 기본값 부여
- 로그인/토큰 재발급 시 app 클라이언트 쿠키 미발급으로 정합성 확보

## 검증
- `./gradlew build` → **BUILD SUCCESSFUL** (컴파일 + 테스트 90/90 통과, 스킵·비활성화 없음)
- 로컬 기동 확인: Spring Boot 4.0.4 컨텍스트 로딩 + 전 테이블 DDL(감사 테이블 포함) 정상, `DELETE /api/v1/auth/members/me` 미인증 요청 → **401**(엔드포인트 등록·보호 동작 확인)

## 범위 및 후속
- 본 PR은 **auth-api 한정**. 연동 계약인 청첩장(Next.js)의 자기 데이터 삭제 + 사유 저장 + auth-api 호출은 **별도 작업**.
- 서비스별 멤버십("연결 서비스 목록"), 부분/전체 탈퇴 분기는 다음 단계로 이연.